### PR TITLE
Complete revision of the `AbsoluteDate` class to work with SPICE(`spiceypy`) and updates to the `position`, `state` modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ __pycache__/
 docs/build/
 htmlcov/
 .coverage
+
+# ignore the SPICE kernels folder
+eosimutils/spice_kernels/*

--- a/eosimutils/base.py
+++ b/eosimutils/base.py
@@ -25,6 +25,14 @@ class EnumBase(str, Enum):
                 return cls(key.upper())
             except:  # pylint: disable=bare-except
                 return None
+    
+    def to_string(self) -> str:
+        """Returns the string representation of the enum value.
+
+        Returns:
+            str: The string representation of the enum value.
+        """
+        return str(self.value)
 
 
 class ReferenceFrame(EnumBase):

--- a/eosimutils/base.py
+++ b/eosimutils/base.py
@@ -25,7 +25,7 @@ class EnumBase(str, Enum):
                 return cls(key.upper())
             except:  # pylint: disable=bare-except
                 return None
-    
+
     def to_string(self) -> str:
         """Returns the string representation of the enum value.
 

--- a/eosimutils/position.py
+++ b/eosimutils/position.py
@@ -6,7 +6,7 @@ Collection of classes and functions for handling position information.
 """
 
 import numpy as np
-from typing import Dict, Any, List, Optional
+from typing import Dict, Any, List, Optional, Union
 
 from skyfield.api import wgs84 as skyfield_wgs84
 
@@ -28,13 +28,13 @@ class Cartesian3DPosition:
 
     @staticmethod
     def from_list(
-        list_in: List[float], frame: Optional[ReferenceFrame]
+        list_in: List[float], frame: Optional[Union[ReferenceFrame, str, None]]=None
     ) -> "Cartesian3DPosition":
         """Construct a Cartesian3DPosition object from a list.
 
         Args:
             list_in (List[float]): Position coordinates in kilometers.
-            frame (ReferenceFrame): The reference-frame.
+            frame (Union[ReferenceFrame, str, None]): The reference-frame as a ReferenceFrame object, string, or None.
 
         Returns:
             Cartesian3DPosition: Cartesian3DPosition object.
@@ -43,6 +43,10 @@ class Cartesian3DPosition:
             raise ValueError("The list must contain exactly 3 elements.")
         if not all(isinstance(coord, (int, float)) for coord in list_in):
             raise ValueError("All elements in list_in must be numeric values.")
+        if isinstance(frame, str):
+            frame = ReferenceFrame.get(frame)
+        if frame is not None and not isinstance(frame, ReferenceFrame):
+            raise ValueError("frame must be a ReferenceFrame object, a valid string, or None.")
         return Cartesian3DPosition(list_in[0], list_in[1], list_in[2], frame)
 
     def to_list(self) -> List[float]:
@@ -64,13 +68,13 @@ class Cartesian3DPosition:
                 - "x" (float): The x-coordinate in kilometers.
                 - "y" (float): The y-coordinate in kilometers.
                 - "z" (float): The z-coordinate in kilometers.
-                - "frame" (str): The reference-frame,
-                                see :class:`orbitpy.util.ReferenceFrame`.
+                - "frame" (str, optional): The reference-frame,
+                                           see :class:`eosimutil.base.ReferenceFrame`.
 
         Returns:
             Cartesian3DPosition: Cartesian3DPosition object.
         """
-        frame = ReferenceFrame.get(dict_in["frame"])
+        frame = ReferenceFrame.get(dict_in["frame"]) if "frame" in dict_in else None
         return Cartesian3DPosition(
             dict_in["x"], dict_in["y"], dict_in["z"], frame
         )
@@ -104,13 +108,13 @@ class Cartesian3DVelocity:
 
     @staticmethod
     def from_list(
-        list_in: List[float], frame: Optional[ReferenceFrame]
+        list_in: List[float], frame: Optional[Union[ReferenceFrame, str, None]]=None
     ) -> "Cartesian3DVelocity":
         """Construct a Cartesian3DVelocity object from a list.
 
         Args:
             list_in (List[float]): Velocity in km-per-s.
-            frame (ReferenceFrame): The reference-frame.
+            frame (Union[ReferenceFrame, str, None]): The reference-frame as a ReferenceFrame object, string, or None.
 
         Returns:
             Cartesian3DVelocity: Cartesian3DVelocity object.
@@ -119,6 +123,10 @@ class Cartesian3DVelocity:
             raise ValueError("The list must contain exactly 3 elements.")
         if not all(isinstance(coord, (int, float)) for coord in list_in):
             raise ValueError("All elements in list_in must be numeric values.")
+        if isinstance(frame, str):
+            frame = ReferenceFrame.get(frame)
+        if frame is not None and not isinstance(frame, ReferenceFrame):
+            raise ValueError("frame must be a ReferenceFrame object, a valid string, or None.")
         return Cartesian3DVelocity(list_in[0], list_in[1], list_in[2], frame)
 
     def to_list(self) -> List[float]:
@@ -140,13 +148,13 @@ class Cartesian3DVelocity:
                 - "vx" (float): The x-coordinate in km-per-s.
                 - "vy" (float): The y-coordinate in km-per-s.
                 - "vz" (float): The z-coordinate in km-per-s.
-                - "frame" (str): The reference-frame,
-                    see :class:`orbitpy.util.ReferenceFrame`.
+                - "frame" (str, optional): The reference-frame,
+                                           see :class:`eosimutil.base.ReferenceFrame`.
 
         Returns:
             Cartesian3DVelocity: Cartesian3DVelocity object.
         """
-        frame = ReferenceFrame.get(dict_in["frame"])
+        frame = ReferenceFrame.get(dict_in["frame"]) if "frame" in dict_in else None
         return Cartesian3DVelocity(
             dict_in["vx"], dict_in["vy"], dict_in["vz"], frame
         )

--- a/eosimutils/position.py
+++ b/eosimutils/position.py
@@ -28,13 +28,14 @@ class Cartesian3DPosition:
 
     @staticmethod
     def from_list(
-        list_in: List[float], frame: Optional[Union[ReferenceFrame, str, None]]=None
+        list_in: List[float],
+        frame: Optional[Union[ReferenceFrame, str, None]] = None,
     ) -> "Cartesian3DPosition":
         """Construct a Cartesian3DPosition object from a list.
 
         Args:
             list_in (List[float]): Position coordinates in kilometers.
-            frame (Union[ReferenceFrame, str, None]): The reference-frame as a ReferenceFrame object, string, or None.
+            frame (Union[ReferenceFrame, str, None]): Reference-frame.
 
         Returns:
             Cartesian3DPosition: Cartesian3DPosition object.
@@ -46,7 +47,9 @@ class Cartesian3DPosition:
         if isinstance(frame, str):
             frame = ReferenceFrame.get(frame)
         if frame is not None and not isinstance(frame, ReferenceFrame):
-            raise ValueError("frame must be a ReferenceFrame object, a valid string, or None.")
+            raise ValueError(
+                "frame must be a ReferenceFrame object, a valid string, or None."
+            )
         return Cartesian3DPosition(list_in[0], list_in[1], list_in[2], frame)
 
     def to_list(self) -> List[float]:
@@ -74,7 +77,9 @@ class Cartesian3DPosition:
         Returns:
             Cartesian3DPosition: Cartesian3DPosition object.
         """
-        frame = ReferenceFrame.get(dict_in["frame"]) if "frame" in dict_in else None
+        frame = (
+            ReferenceFrame.get(dict_in["frame"]) if "frame" in dict_in else None
+        )
         return Cartesian3DPosition(
             dict_in["x"], dict_in["y"], dict_in["z"], frame
         )
@@ -108,13 +113,14 @@ class Cartesian3DVelocity:
 
     @staticmethod
     def from_list(
-        list_in: List[float], frame: Optional[Union[ReferenceFrame, str, None]]=None
+        list_in: List[float],
+        frame: Optional[Union[ReferenceFrame, str, None]] = None,
     ) -> "Cartesian3DVelocity":
         """Construct a Cartesian3DVelocity object from a list.
 
         Args:
             list_in (List[float]): Velocity in km-per-s.
-            frame (Union[ReferenceFrame, str, None]): The reference-frame as a ReferenceFrame object, string, or None.
+            frame (Union[ReferenceFrame, str, None]): Reference-frame.
 
         Returns:
             Cartesian3DVelocity: Cartesian3DVelocity object.
@@ -126,7 +132,9 @@ class Cartesian3DVelocity:
         if isinstance(frame, str):
             frame = ReferenceFrame.get(frame)
         if frame is not None and not isinstance(frame, ReferenceFrame):
-            raise ValueError("frame must be a ReferenceFrame object, a valid string, or None.")
+            raise ValueError(
+                "frame must be a ReferenceFrame object, a valid string, or None."
+            )
         return Cartesian3DVelocity(list_in[0], list_in[1], list_in[2], frame)
 
     def to_list(self) -> List[float]:
@@ -154,7 +162,9 @@ class Cartesian3DVelocity:
         Returns:
             Cartesian3DVelocity: Cartesian3DVelocity object.
         """
-        frame = ReferenceFrame.get(dict_in["frame"]) if "frame" in dict_in else None
+        frame = (
+            ReferenceFrame.get(dict_in["frame"]) if "frame" in dict_in else None
+        )
         return Cartesian3DVelocity(
             dict_in["vx"], dict_in["vy"], dict_in["vz"], frame
         )

--- a/eosimutils/spicekernels.py
+++ b/eosimutils/spicekernels.py
@@ -9,65 +9,68 @@ import spiceypy as spice
 import os
 import urllib.request
 
+
 def download_latest_kernels() -> None:
-   """Download the latest SPICE kernels from the NAIF website.
+    """Download the latest SPICE kernels from the NAIF website.
 
-   This function downloads the latest SPICE kernels from the NAIF website
-   and stores them in a local directory. The directory is created if it
-   does not exist.
+    This function downloads the latest SPICE kernels from the NAIF website
+    and stores them in a local directory. The directory is created if it
+    does not exist.
 
-   Raises:
-      FileNotFoundError: If the SPICE kernel files are not found.
-   """
-   # Define the directory to save kernels
-   kernel_dir = os.path.join(os.path.dirname(__file__), "spice_kernels")
-   os.makedirs(kernel_dir, exist_ok=True) # do not create the directory if it already exists
+    Raises:
+       FileNotFoundError: If the SPICE kernel files are not found.
+    """
+    # Define the directory to save kernels
+    kernel_dir = os.path.join(os.path.dirname(__file__), "spice_kernels")
+    os.makedirs(
+        kernel_dir, exist_ok=True
+    )  # do not create the directory if it already exists
 
-   # Define the latest kernel URLs
-   kernels = {
-      "LSK": "https://naif.jpl.nasa.gov/pub/naif/generic_kernels/lsk/naif0012.tls",
-      "BPC": "https://naif.jpl.nasa.gov/pub/naif/generic_kernels/pck/earth_000101_250627_250331.bpc",
-   }
+    # Define the latest kernel URLs
+    kernels = {
+        "LSK": "https://naif.jpl.nasa.gov/pub/naif/generic_kernels/lsk/naif0012.tls", #pylint: disable=line-too-long
+        "BPC": "https://naif.jpl.nasa.gov/pub/naif/generic_kernels/pck/earth_000101_250627_250331.bpc", #pylint: disable=line-too-long
+    }
 
-   # Function to download a kernel if it doesn't already exist
-   def download_kernel(url):
-      filename = os.path.join(kernel_dir, os.path.basename(url))
-      
-      if os.path.exists(filename):
-         pass
-      else:
-         try:
-               print(f"Downloading {filename}...")
-               urllib.request.urlretrieve(url, filename)
-               print(f"Downloaded and saved: {filename}\n")
-         except Exception as e:
-               print(f"Failed to download {filename}: {e}")
+    # Function to download a kernel if it doesn't already exist
+    def download_kernel(url):
+        filename = os.path.join(kernel_dir, os.path.basename(url))
 
-   # Download the required kernels
-   for url in kernels.values():
-      download_kernel(url)
+        if os.path.exists(filename):
+            pass
+        else:
+            try:
+                print(f"Downloading {filename}...")
+                urllib.request.urlretrieve(url, filename)
+                print(f"Downloaded and saved: {filename}\n")
+            except Exception as e: #pylint: disable=broad-exception-caught
+                print(f"Failed to download {filename}: {e}")
+
+    # Download the required kernels
+    for url in kernels.values():
+        download_kernel(url)
 
 
 def load_spice_kernels() -> None:
-   """Load SPICE kernel files required for time conversions.
+    """Load SPICE kernel files required for time conversions.
 
-   Raises:
-      FileNotFoundError: If the SPICE kernel files are not found.
-   """
-   # Download the kernels if they are not already present
-   download_latest_kernels()
+    Raises:
+       FileNotFoundError: If the SPICE kernel files are not found.
+    """
+    # Download the kernels if they are not already present
+    download_latest_kernels()
 
-   # Load the kernels
-   kernel_dir = os.path.join(os.path.dirname(__file__), "spice_kernels")
-   leap_seconds_kernel = os.path.join(kernel_dir, "naif0012.tls")
-   eop_kernel = os.path.join(kernel_dir, "earth_000101_250627_250331.bpc")
+    # Load the kernels
+    kernel_dir = os.path.join(os.path.dirname(__file__), "spice_kernels")
+    leap_seconds_kernel = os.path.join(kernel_dir, "naif0012.tls")
+    eop_kernel = os.path.join(kernel_dir, "earth_000101_250627_250331.bpc")
 
-   try:
-      spice.furnsh(leap_seconds_kernel)  # Load Leap Seconds Kernel
-      spice.furnsh(eop_kernel)  # Load High-precision EOP Kernel
-   except spice.utils.exceptions.SpiceyError as e:
-      raise FileNotFoundError(
+    try:
+        spice.furnsh(leap_seconds_kernel)  # Load Leap Seconds Kernel
+        spice.furnsh(eop_kernel)  # Load High-precision EOP Kernel
+    except spice.utils.exceptions.SpiceyError as e:
+        raise FileNotFoundError(
             f"SPICE kernel files not found. Please check the paths:\n"
             f"Leap Seconds Kernel: {leap_seconds_kernel}\n"
             f"EOP Kernel: {eop_kernel}"
-      ) from e
+        ) from e

--- a/eosimutils/spicekernels.py
+++ b/eosimutils/spicekernels.py
@@ -1,0 +1,73 @@
+"""
+.. module:: eosimutils.spicekernels
+   :synopsis: Module for handling SPICE kernels.
+
+Module for handling SPICE kernels.
+"""
+
+import spiceypy as spice
+import os
+import urllib.request
+
+def download_latest_kernels() -> None:
+   """Download the latest SPICE kernels from the NAIF website.
+
+   This function downloads the latest SPICE kernels from the NAIF website
+   and stores them in a local directory. The directory is created if it
+   does not exist.
+
+   Raises:
+      FileNotFoundError: If the SPICE kernel files are not found.
+   """
+   # Define the directory to save kernels
+   kernel_dir = os.path.join(os.path.dirname(__file__), "spice_kernels")
+   os.makedirs(kernel_dir, exist_ok=True) # do not create the directory if it already exists
+
+   # Define the latest kernel URLs
+   kernels = {
+      "LSK": "https://naif.jpl.nasa.gov/pub/naif/generic_kernels/lsk/naif0012.tls",
+      "BPC": "https://naif.jpl.nasa.gov/pub/naif/generic_kernels/pck/earth_000101_250627_250331.bpc",
+   }
+
+   # Function to download a kernel if it doesn't already exist
+   def download_kernel(url):
+      filename = os.path.join(kernel_dir, os.path.basename(url))
+      
+      if os.path.exists(filename):
+         pass
+      else:
+         try:
+               print(f"Downloading {filename}...")
+               urllib.request.urlretrieve(url, filename)
+               print(f"Downloaded and saved: {filename}\n")
+         except Exception as e:
+               print(f"Failed to download {filename}: {e}")
+
+   # Download the required kernels
+   for url in kernels.values():
+      download_kernel(url)
+
+
+def load_spice_kernels() -> None:
+   """Load SPICE kernel files required for time conversions.
+
+   Raises:
+      FileNotFoundError: If the SPICE kernel files are not found.
+   """
+   # Download the kernels if they are not already present
+   download_latest_kernels()
+
+   # Load the kernels
+   kernel_dir = os.path.join(os.path.dirname(__file__), "spice_kernels")
+   leap_seconds_kernel = os.path.join(kernel_dir, "naif0012.tls")
+   eop_kernel = os.path.join(kernel_dir, "earth_000101_250627_250331.bpc")
+
+   try:
+      spice.furnsh(leap_seconds_kernel)  # Load Leap Seconds Kernel
+      spice.furnsh(eop_kernel)  # Load High-precision EOP Kernel
+   except spice.utils.exceptions.SpiceyError as e:
+      raise FileNotFoundError(
+            f"SPICE kernel files not found. Please check the paths:\n"
+            f"Leap Seconds Kernel: {leap_seconds_kernel}\n"
+            f"EOP Kernel: {eop_kernel}"
+      ) from e

--- a/eosimutils/state.py
+++ b/eosimutils/state.py
@@ -51,8 +51,8 @@ class CartesianState:
                 The dictionary should contain the following key-value pairs:
                 - "time" (dict): Dictionary with the date-time information.
                         See  :class:`orbitpy.util.AbsoluteDate.from_dict()`.
-                - "frame" (str): The reference-frame
-                                 See :class:`orbitpy.util.ReferenceFrame`.
+                - "frame" (str, optional): The reference-frame
+                                           See :class:`eosimutil.base.ReferenceFrame`.
                 - "position" (List[float]): Position vector in kilometers.
                 - "velocity" (List[float]): Velocity vector in km-per-s.
 
@@ -60,7 +60,7 @@ class CartesianState:
             CartesianState: CartesianState object.
         """
         time = AbsoluteDate.from_dict(dict_in["time"])
-        frame = ReferenceFrame.get(dict_in["frame"])
+        frame = ReferenceFrame.get(dict_in["frame"]) if "frame" in dict_in else None
         position = Cartesian3DPosition.from_list(dict_in["position"], frame)
         velocity = Cartesian3DVelocity.from_list(dict_in["velocity"], frame)
         return CartesianState(time, position, velocity, frame)

--- a/eosimutils/state.py
+++ b/eosimutils/state.py
@@ -60,7 +60,9 @@ class CartesianState:
             CartesianState: CartesianState object.
         """
         time = AbsoluteDate.from_dict(dict_in["time"])
-        frame = ReferenceFrame.get(dict_in["frame"]) if "frame" in dict_in else None
+        frame = (
+            ReferenceFrame.get(dict_in["frame"]) if "frame" in dict_in else None
+        )
         position = Cartesian3DPosition.from_list(dict_in["position"], frame)
         velocity = Cartesian3DVelocity.from_list(dict_in["velocity"], frame)
         return CartesianState(time, position, velocity, frame)

--- a/eosimutils/time.py
+++ b/eosimutils/time.py
@@ -21,6 +21,7 @@ class TimeFormat(EnumBase):
     """
     Enumeration of recognized time formats.
     """
+
     GREGORIAN_DATE = "GREGORIAN_DATE"
     JULIAN_DATE = "JULIAN_DATE"
 
@@ -29,24 +30,25 @@ class TimeScale(EnumBase):
     """
     Enumeration of recognized time scales.
     """
+
     UTC = "UTC"
 
 
 class AbsoluteDate:
     """Handles date-time information with support to Julian and Gregorian
-    date-time formats and UTC time scale. Date-time is stored 
-    internally as Ephemeris Time (ET) (Barycentric Dynamical Time (TDB)) 
+    date-time formats and UTC time scale. Date-time is stored
+    internally as Ephemeris Time (ET) (Barycentric Dynamical Time (TDB))
     as defined in SPICE."""
 
     def __init__(self, ephemeris_time: float) -> None:
         """Constructor for the AbsoluteDate class.
 
         Args:
-            ephemeris_time (float): Ephemeris Time (ET) / 
+            ephemeris_time (float): Ephemeris Time (ET) /
                             Barycentric Dynamical Time (TDB)
         """
         self.ephemeris_time = ephemeris_time
-    
+
     @classmethod
     def from_dict(cls, dict_in: Dict[str, Any]) -> "AbsoluteDate":
         """Construct an AbsoluteDate object from a dictionary.
@@ -62,7 +64,8 @@ class AbsoluteDate:
                                       See :class:`eosimutils.time.TimeScale` for options.
 
                 For "Gregorian_Date" format:
-                - "calendar_date" (str): The date-time in YYYY-MM-DDTHH:MM:SS.SSS format (e.g., "2025-03-31T12:34:56.789").
+                - "calendar_date" (str): The date-time in YYYY-MM-DDTHH:MM:SS.SSS format. 
+                                         (e.g., "2025-03-31T12:34:56.789").
 
                 For "Julian_Date" format:
                 - "jd" (float): The Julian Date.
@@ -96,11 +99,10 @@ class AbsoluteDate:
 
         return cls(ephemeris_time=spice_ephemeris_time)
 
-
     def to_dict(
-        self, 
+        self,
         time_format: Union[TimeFormat, str] = "GREGORIAN_DATE",
-        time_scale: Union[TimeScale, str] = "UTC"
+        time_scale: Union[TimeScale, str] = "UTC",
     ) -> Dict[str, Any]:
         """Convert the AbsoluteDate object to a dictionary.
 
@@ -108,8 +110,8 @@ class AbsoluteDate:
             time_format (str): The type of date-time format to use
                                 ("GREGORIAN_DATE" or "JULIAN_DATE").
                                 Default is "GREGORIAN_DATE".
-            
-            time_scale (str): The time scale to use (e.g., "UTC"). 
+
+            time_scale (str): The time scale to use (e.g., "UTC").
                                 Default is "UTC".
 
 
@@ -135,24 +137,24 @@ class AbsoluteDate:
                     "time_scale": time_scale.to_string(),
                 }
             elif time_format == TimeFormat.JULIAN_DATE:
-                
-                    # Convert Ephemeris Time (ET) to Julian Date UTC
-                    time_string = spice.et2utc(self.ephemeris_time, "J", 7)
-                    # Parse the Julian Date value
-                    jd_value = float(time_string.split()[1])  # Extract and convert the value to float
 
-                    return {
-                        "time_format": "JULIAN_DATE",
-                        "jd": jd_value,
-                        "time_scale": time_scale.to_string(),
-                    }
+                # Convert Ephemeris Time (ET) to Julian Date UTC
+                time_string = spice.et2utc(self.ephemeris_time, "J", 7)
+                # Parse the Julian Date value
+                jd_value = float(
+                    time_string.split()[1]
+                )  # Extract and convert the value to float
+
+                return {
+                    "time_format": "JULIAN_DATE",
+                    "jd": jd_value,
+                    "time_scale": time_scale.to_string(),
+                }
             else:
                 raise ValueError(f"Unsupported date-time format: {time_format}")
         else:
-            raise ValueError(
-                f"Unsupported time scale: {time_scale}."
-            )
-    
+            raise ValueError(f"Unsupported time scale: {time_scale}.")
+
     def to_astropy_time(self) -> Astropy_Time:
         """Convert the AbsoluteDate object to an Astropy Time object.
 
@@ -173,8 +175,12 @@ class AbsoluteDate:
         date_part, time_part = gregorian_utc_time_string.split("T")
         year, month, day = map(int, date_part.split("-"))
         hour, minute = map(int, time_part.split(":")[:2])
-        second = int(float(time_part.split(":")[2]))  # Handle fractional seconds
-        skyfield_time = ts.utc(year, month=month, day=day, hour=hour, minute=minute, second=second)
+        second = int(
+            float(time_part.split(":")[2])
+        )  # Handle fractional seconds
+        skyfield_time = ts.utc(
+            year, month=month, day=day, hour=hour, minute=minute, second=second
+        )
         return skyfield_time
 
     def __eq__(self, value):

--- a/eosimutils/time.py
+++ b/eosimutils/time.py
@@ -5,8 +5,11 @@
 Collection of classes and functions for handling time information.
 """
 
-from typing import Dict, Any
+from typing import Dict, Any, Union
 
+import spiceypy as spice
+
+from eosimutils.spicekernels import load_spice_kernels
 from astropy.time import Time as Astropy_Time
 from skyfield.api import load as Skyfield_Load
 from skyfield.timelib import Time as Skyfield_Time
@@ -18,7 +21,6 @@ class TimeFormat(EnumBase):
     """
     Enumeration of recognized time formats.
     """
-
     GREGORIAN_DATE = "GREGORIAN_DATE"
     JULIAN_DATE = "JULIAN_DATE"
 
@@ -27,27 +29,24 @@ class TimeScale(EnumBase):
     """
     Enumeration of recognized time scales.
     """
-
-    UT1 = "UT1"
     UTC = "UTC"
 
 
 class AbsoluteDate:
     """Handles date-time information with support to Julian and Gregorian
-    date-time formats and UT1 and UTC time scales. Date-time is managed
-    internally using the Astropy Time object.
+    date-time formats and UTC time scale. Date-time is stored 
+    internally as Ephemeris Time (ET) (Barycentric Dynamical Time (TDB)) 
+    as defined in SPICE."""
 
-    .. note:: Skyfield Time was not used since it appears not to
-    support handling of JD-UTC."""
-
-    def __init__(self, astropy_time: Astropy_Time) -> None:
+    def __init__(self, ephemeris_time: float) -> None:
         """Constructor for the AbsoluteDate class.
 
         Args:
-            astropy_time (astropy.time.Time): Astropy Time object.
+            ephemeris_time (float): Ephemeris Time (ET) / 
+                            Barycentric Dynamical Time (TDB)
         """
-        self.astropy_time = astropy_time
-
+        self.ephemeris_time = ephemeris_time
+    
     @classmethod
     def from_dict(cls, dict_in: Dict[str, Any]) -> "AbsoluteDate":
         """Construct an AbsoluteDate object from a dictionary.
@@ -58,16 +57,12 @@ class AbsoluteDate:
                 - "time_format" (str): The date-time format, either
                                        "Gregorian_Date" or "Julian_Date"
                                        (case-insensitive).
-                - "time_scale" (str): The time scale, e.g., "UTC" or "UT1"
+                - "time_scale" (str): The time scale, e.g., "UTC"
                                       (case-insensitive).
+                                      See :class:`eosimutils.time.TimeScale` for options.
 
                 For "Gregorian_Date" format:
-                - "year" (int): The year component of the date.
-                - "month" (int): The month component of the date.
-                - "day" (int): The day component of the date.
-                - "hour" (int): The hour component of the time.
-                - "minute" (int): The minute component of the time.
-                - "second" (float): The second component of the time.
+                - "calendar_date" (str): The date-time in YYYY-MM-DDTHH:MM:SS.SSS format (e.g., "2025-03-31T12:34:56.789").
 
                 For "Julian_Date" format:
                 - "jd" (float): The Julian Date.
@@ -77,82 +72,95 @@ class AbsoluteDate:
         """
         time_scale: TimeScale = TimeScale.get(dict_in["time_scale"])
         time_format: TimeFormat = TimeFormat.get(dict_in["time_format"])
-        if time_format == TimeFormat.GREGORIAN_DATE:
-            year: int = dict_in["year"]
-            month: int = dict_in["month"]
-            day: int = dict_in["day"]
-            hour: int = dict_in["hour"]
-            minute: int = dict_in["minute"]
-            second: float = dict_in["second"]
-            astropy_time = Astropy_Time(
-                f"{year}-{month:02d}-{day:02d}T{hour:02d}:{minute:02d}:{second:06.3f}",  # pylint: disable=line-too-long
-                format="isot",
-                scale=time_scale.value.lower(),
-            )
-        elif time_format == TimeFormat.JULIAN_DATE:
-            jd: float = dict_in["jd"]
-            astropy_time = Astropy_Time(
-                jd, format="jd", scale=time_scale.value.lower()
-            )
+
+        # Load SPICE kernel files
+        load_spice_kernels()
+
+        if time_scale == TimeScale.UTC:
+
+            if time_format == TimeFormat.GREGORIAN_DATE:
+                # Parse the calendar date string and convert to Ephemeris Time (ET)
+                calendar_date_str: str = dict_in["calendar_date"]
+                spice_ephemeris_time = spice.str2et(calendar_date_str)
+
+            elif time_format == TimeFormat.JULIAN_DATE:
+                # Convert Julian Date UTC to ET
+                jd: float = dict_in["jd"]
+                time_string = f"jd {jd}"  # Format as Julian Date string
+                spice_ephemeris_time = spice.str2et(time_string)
+
+            else:
+                raise ValueError(f"Unsupported date-time format: {time_format}")
         else:
-            raise ValueError(f"Unsupported date-time format: {time_format}")
-        return cls(astropy_time=astropy_time)
+            raise ValueError(f"Unsupported time scale: {time_scale}.")
+
+        return cls(ephemeris_time=spice_ephemeris_time)
+
 
     def to_dict(
-        self, time_format_str: str = "GREGORIAN_DATE"
+        self, 
+        time_format: Union[TimeFormat, str] = "GREGORIAN_DATE",
+        time_scale: Union[TimeScale, str] = "UTC"
     ) -> Dict[str, Any]:
         """Convert the AbsoluteDate object to a dictionary.
 
         Args:
             time_format (str): The type of date-time format to use
                                 ("GREGORIAN_DATE" or "JULIAN_DATE").
+                                Default is "GREGORIAN_DATE".
+            
+            time_scale (str): The time scale to use (e.g., "UTC"). 
+                                Default is "UTC".
+
 
         Returns:
             dict: Dictionary with the date-time information.
         """
-        time_format = TimeFormat.get(time_format_str)
-        if time_format == TimeFormat.GREGORIAN_DATE:
-            return {
-                "time_format": "GREGORIAN_DATE",
-                "year": self.astropy_time.datetime.year,
-                "month": self.astropy_time.datetime.month,
-                "day": self.astropy_time.datetime.day,
-                "hour": self.astropy_time.datetime.hour,
-                "minute": self.astropy_time.datetime.minute,
-                "second": self.astropy_time.datetime.second,
-                "time_scale": self.astropy_time.scale,
-            }
-        elif time_format == TimeFormat.JULIAN_DATE:
-            return {
-                "time_format": "JULIAN_DATE",
-                "jd": self.astropy_time.jd,
-                "time_scale": self.astropy_time.scale,
-            }
+
+        # Load SPICE kernel files
+        load_spice_kernels()
+
+        time_format = TimeFormat.get(time_format)
+        time_scale = TimeScale.get(time_scale)
+
+        if time_scale == TimeScale.UTC:
+
+            if time_format == TimeFormat.GREGORIAN_DATE:
+
+                # Convert Ephemeris Time (ET) to Gregorian Date UTC
+                time_string = spice.et2utc(self.ephemeris_time, "ISOC", 3)
+                return {
+                    "time_format": "GREGORIAN_DATE",
+                    "calendar_date": time_string,
+                    "time_scale": time_scale.to_string(),
+                }
+            elif time_format == TimeFormat.JULIAN_DATE:
+                
+                    # Convert Ephemeris Time (ET) to Julian Date UTC
+                    time_string = spice.et2utc(self.ephemeris_time, "J", 7)
+                    # Parse the Julian Date value
+                    jd_value = float(time_string.split()[1])  # Extract and convert the value to float
+
+                    return {
+                        "time_format": "JULIAN_DATE",
+                        "jd": jd_value,
+                        "time_scale": time_scale.to_string(),
+                    }
+            else:
+                raise ValueError(f"Unsupported date-time format: {time_format}")
         else:
-            raise ValueError(f"Unsupported date-time format: {time_format}")
-
-    def __eq__(self, other: object) -> bool:
-        """
-        Check if two AbsoluteDate objects are equal.
-
-        Args:
-            other (object): The object to compare with.
-
-        Returns:
-            bool: True if the two AbsoluteDate objects represent the
-                  same date and time, False otherwise.
-        """
-        if not isinstance(other, AbsoluteDate):
-            return False
-        return self.astropy_time == other.astropy_time
-
+            raise ValueError(
+                f"Unsupported time scale: {time_scale}."
+            )
+    
     def to_astropy_time(self) -> Astropy_Time:
         """Convert the AbsoluteDate object to an Astropy Time object.
 
         Returns:
             astropy.time.Time: Astropy Time object.
         """
-        return self.astropy_time
+        gregorian_utc_time_string = spice.et2utc(self.ephemeris_time, "ISOC", 3)
+        return Astropy_Time(gregorian_utc_time_string, scale="utc")
 
     def to_skyfield_time(self) -> Skyfield_Time:
         """Convert the AbsoluteDate object to a Skyfield Time object.
@@ -161,5 +169,23 @@ class AbsoluteDate:
             skyfield.time.Time: Skyfield Time object.
         """
         ts = Skyfield_Load.timescale()
-        skyfield_time = ts.from_astropy(self.astropy_time)
+        gregorian_utc_time_string = spice.et2utc(self.ephemeris_time, "ISOC", 3)
+        date_part, time_part = gregorian_utc_time_string.split("T")
+        year, month, day = map(int, date_part.split("-"))
+        hour, minute = map(int, time_part.split(":")[:2])
+        second = int(float(time_part.split(":")[2]))  # Handle fractional seconds
+        skyfield_time = ts.utc(year, month=month, day=day, hour=hour, minute=minute, second=second)
         return skyfield_time
+
+    def __eq__(self, value):
+        """Check equality of two AbsoluteDate objects.
+
+        Args:
+            value (AbsoluteDate): The AbsoluteDate object to compare with.
+
+        Returns:
+            bool: True if the objects are equal, False otherwise.
+        """
+        if not isinstance(value, AbsoluteDate):
+            return False
+        return self.ephemeris_time == value.ephemeris_time

--- a/tests/test_position.py
+++ b/tests/test_position.py
@@ -35,15 +35,11 @@ class TestCartesian3DPosition(unittest.TestCase):
         np.testing.assert_array_equal(pos.coords, [self.x, self.y, self.z])
         self.assertEqual(pos.frame, ReferenceFrame.ITRF)
 
-        pos = Cartesian3DPosition.from_list(
-            [self.x, self.y, self.z], "ITRF"
-        )
+        pos = Cartesian3DPosition.from_list([self.x, self.y, self.z], "ITRF")
         np.testing.assert_array_equal(pos.coords, [self.x, self.y, self.z])
         self.assertEqual(pos.frame, ReferenceFrame.ITRF)
 
-        pos = Cartesian3DPosition.from_list(
-            [self.x, self.y, self.z]
-        )
+        pos = Cartesian3DPosition.from_list([self.x, self.y, self.z])
         np.testing.assert_array_equal(pos.coords, [self.x, self.y, self.z])
         self.assertIsNone(pos.frame)
 
@@ -56,7 +52,7 @@ class TestCartesian3DPosition(unittest.TestCase):
         pos = Cartesian3DPosition.from_dict(dict_in)
         np.testing.assert_array_equal(pos.coords, [self.x, self.y, self.z])
         self.assertEqual(pos.frame, ReferenceFrame.GCRF)
-    
+
     def test_from_dict_no_frame(self):
         dict_in = {"x": self.x, "y": self.y, "z": self.z}
         pos = Cartesian3DPosition.from_dict(dict_in)
@@ -94,15 +90,11 @@ class TestCartesian3DVelocity(unittest.TestCase):
         np.testing.assert_array_equal(vel.coords, [self.vx, self.vy, self.vz])
         self.assertEqual(vel.frame, ReferenceFrame.ITRF)
 
-        vel = Cartesian3DVelocity.from_list(
-            [self.vx, self.vy, self.vz], "ITRF"
-        )
+        vel = Cartesian3DVelocity.from_list([self.vx, self.vy, self.vz], "ITRF")
         np.testing.assert_array_equal(vel.coords, [self.vx, self.vy, self.vz])
         self.assertEqual(vel.frame, ReferenceFrame.ITRF)
 
-        vel = Cartesian3DVelocity.from_list(
-            [self.vx, self.vy, self.vz]
-        )
+        vel = Cartesian3DVelocity.from_list([self.vx, self.vy, self.vz])
         np.testing.assert_array_equal(vel.coords, [self.vx, self.vy, self.vz])
         self.assertIsNone(vel.frame)
 
@@ -117,7 +109,7 @@ class TestCartesian3DVelocity(unittest.TestCase):
         vel = Cartesian3DVelocity.from_dict(dict_in)
         np.testing.assert_array_equal(vel.coords, [self.vx, self.vy, self.vz])
         self.assertEqual(vel.frame, ReferenceFrame.GCRF)
-    
+
     def from_dict_no_frame(self):
         dict_in = {"vx": self.vx, "vy": self.vy, "vz": self.vz}
         vel = Cartesian3DVelocity.from_dict(dict_in)

--- a/tests/test_position.py
+++ b/tests/test_position.py
@@ -35,6 +35,18 @@ class TestCartesian3DPosition(unittest.TestCase):
         np.testing.assert_array_equal(pos.coords, [self.x, self.y, self.z])
         self.assertEqual(pos.frame, ReferenceFrame.ITRF)
 
+        pos = Cartesian3DPosition.from_list(
+            [self.x, self.y, self.z], "ITRF"
+        )
+        np.testing.assert_array_equal(pos.coords, [self.x, self.y, self.z])
+        self.assertEqual(pos.frame, ReferenceFrame.ITRF)
+
+        pos = Cartesian3DPosition.from_list(
+            [self.x, self.y, self.z]
+        )
+        np.testing.assert_array_equal(pos.coords, [self.x, self.y, self.z])
+        self.assertIsNone(pos.frame)
+
     def test_to_list(self):
         pos = Cartesian3DPosition(self.x, self.y, self.z, ReferenceFrame.GCRF)
         self.assertEqual(pos.to_list(), [self.x, self.y, self.z])
@@ -44,6 +56,12 @@ class TestCartesian3DPosition(unittest.TestCase):
         pos = Cartesian3DPosition.from_dict(dict_in)
         np.testing.assert_array_equal(pos.coords, [self.x, self.y, self.z])
         self.assertEqual(pos.frame, ReferenceFrame.GCRF)
+    
+    def test_from_dict_no_frame(self):
+        dict_in = {"x": self.x, "y": self.y, "z": self.z}
+        pos = Cartesian3DPosition.from_dict(dict_in)
+        np.testing.assert_array_equal(pos.coords, [self.x, self.y, self.z])
+        self.assertIsNone(pos.frame)
 
     def test_to_dict(self):
         pos = Cartesian3DPosition(self.x, self.y, self.z, ReferenceFrame.ITRF)
@@ -76,6 +94,18 @@ class TestCartesian3DVelocity(unittest.TestCase):
         np.testing.assert_array_equal(vel.coords, [self.vx, self.vy, self.vz])
         self.assertEqual(vel.frame, ReferenceFrame.ITRF)
 
+        vel = Cartesian3DVelocity.from_list(
+            [self.vx, self.vy, self.vz], "ITRF"
+        )
+        np.testing.assert_array_equal(vel.coords, [self.vx, self.vy, self.vz])
+        self.assertEqual(vel.frame, ReferenceFrame.ITRF)
+
+        vel = Cartesian3DVelocity.from_list(
+            [self.vx, self.vy, self.vz]
+        )
+        np.testing.assert_array_equal(vel.coords, [self.vx, self.vy, self.vz])
+        self.assertIsNone(vel.frame)
+
     def test_to_list(self):
         vel = Cartesian3DVelocity(
             self.vx, self.vy, self.vz, ReferenceFrame.GCRF
@@ -87,6 +117,12 @@ class TestCartesian3DVelocity(unittest.TestCase):
         vel = Cartesian3DVelocity.from_dict(dict_in)
         np.testing.assert_array_equal(vel.coords, [self.vx, self.vy, self.vz])
         self.assertEqual(vel.frame, ReferenceFrame.GCRF)
+    
+    def from_dict_no_frame(self):
+        dict_in = {"vx": self.vx, "vy": self.vy, "vz": self.vz}
+        vel = Cartesian3DVelocity.from_dict(dict_in)
+        np.testing.assert_array_equal(vel.coords, [self.vx, self.vy, self.vz])
+        self.assertIsNone(vel.frame)
 
     def test_to_dict(self):
         vel = Cartesian3DVelocity(

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -100,6 +100,25 @@ class TestCartesianState(unittest.TestCase):
             state.velocity.coords, self.velocity.coords
         )
         self.assertEqual(state.frame, self.frame)
+    
+    def from_dict_no_frame(self):
+        """Test from_dict method without frame."""
+        dict_in = {
+            "time": self.time_dict,
+            "position": self.position.to_list(),
+            "velocity": self.velocity.to_list(),
+        }
+        state = CartesianState.from_dict(dict_in)
+        self.assertEqual(
+            state.time.astropy_time.iso, self.time.astropy_time.iso
+        )
+        np.testing.assert_array_equal(
+            state.position.coords, self.position.coords
+        )
+        np.testing.assert_array_equal(
+            state.velocity.coords, self.velocity.coords
+        )
+        self.assertIsNone(state.frame)
 
     def test_to_dict(self):
         state = CartesianState(

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -16,12 +16,7 @@ class TestCartesianState(unittest.TestCase):
     def setUp(self):
         self.time_dict = {
             "time_format": "Gregorian_Date",
-            "year": 2025,
-            "month": 3,
-            "day": 10,
-            "hour": 14,
-            "minute": 30,
-            "second": 0.0,
+            "calendar_date": "2025-03-10T14:30:00.0",
             "time_scale": "utc",
         }
         self.time = AbsoluteDate.from_dict(self.time_dict)
@@ -91,7 +86,7 @@ class TestCartesianState(unittest.TestCase):
         }
         state = CartesianState.from_dict(dict_in)
         self.assertEqual(
-            state.time.astropy_time.iso, self.time.astropy_time.iso
+            state.time, self.time
         )
         np.testing.assert_array_equal(
             state.position.coords, self.position.coords

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -85,9 +85,7 @@ class TestCartesianState(unittest.TestCase):
             "frame": "GCRF",
         }
         state = CartesianState.from_dict(dict_in)
-        self.assertEqual(
-            state.time, self.time
-        )
+        self.assertEqual(state.time, self.time)
         np.testing.assert_array_equal(
             state.position.coords, self.position.coords
         )
@@ -95,7 +93,7 @@ class TestCartesianState(unittest.TestCase):
             state.velocity.coords, self.velocity.coords
         )
         self.assertEqual(state.frame, self.frame)
-    
+
     def from_dict_no_frame(self):
         """Test from_dict method without frame."""
         dict_in = {

--- a/tests/test_time.py
+++ b/tests/test_time.py
@@ -29,7 +29,7 @@ class TestAbsoluteDate(unittest.TestCase):
         # https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/cspice/str2et_c.html
         dict_in = {
             "time_format": "Julian_Date",
-            "jd": 2457949.323611111, # 2017 July 14 19:46:0.0
+            "jd": 2457949.323611111,  # 2017 July 14 19:46:0.0
             "time_scale": "utc",
         }
         absolute_date = AbsoluteDate.from_dict(dict_in)
@@ -39,12 +39,12 @@ class TestAbsoluteDate(unittest.TestCase):
 
     def test_to_dict_gregorian(self):
         absolute_date = AbsoluteDate.from_dict(
-                        {
-                            "time_format": "Gregorian_Date",
-                            "calendar_date": "2025-03-10T14:30:0",
-                            "time_scale": "utc",
-                        }
-                    )
+            {
+                "time_format": "Gregorian_Date",
+                "calendar_date": "2025-03-10T14:30:0",
+                "time_scale": "utc",
+            }
+        )
         dict_out = absolute_date.to_dict("Gregorian_Date", "UTC")
         expected_dict = {
             "time_format": "GREGORIAN_DATE",
@@ -55,12 +55,12 @@ class TestAbsoluteDate(unittest.TestCase):
 
     def test_to_dict_julian(self):
         absolute_date = AbsoluteDate.from_dict(
-                        {
-                            "time_format": "Julian_Date",
-                            "jd": 2457081.10417,
-                            "time_scale": "utc",
-                        }
-                    )
+            {
+                "time_format": "Julian_Date",
+                "jd": 2457081.10417,
+                "time_scale": "utc",
+            }
+        )
         dict_out = absolute_date.to_dict("Julian_Date")
         expected_dict = {
             "time_format": "JULIAN_DATE",
@@ -79,11 +79,9 @@ class TestAbsoluteDate(unittest.TestCase):
         absolute_date = AbsoluteDate.from_dict(dict_in)
         absolute_date_jd = absolute_date.to_dict("Julian_Date")
         # Validation data from: https://aa.usno.navy.mil/data/JulianDate
-        # Since both dates are in UTC, it may not matter that the USNO 
-        # website specifies the time scale as UT1. 
-        self.assertAlmostEqual(
-            absolute_date_jd["jd"], 2460745.558067, places=5
-        )
+        # Since both dates are in UTC, it may not matter that the USNO
+        # website specifies the time scale as UT1.
+        self.assertAlmostEqual(absolute_date_jd["jd"], 2460745.558067, places=5)
 
     def test_julian_to_gregorian(self):
         # Initialize with Julian Date
@@ -95,14 +93,14 @@ class TestAbsoluteDate(unittest.TestCase):
         absolute_date = AbsoluteDate.from_dict(dict_in)
         absolute_date_gregorian = absolute_date.to_dict("Gregorian_Date", "UTC")
         # Validation data from: https://aa.usno.navy.mil/data/JulianDate
-        # Since both dates are in UTC, it may not matter that the USNO 
-        # website specifies the time scale as UT1. 
+        # Since both dates are in UTC, it may not matter that the USNO
+        # website specifies the time scale as UT1.
         self.assertEqual(
             absolute_date_gregorian["calendar_date"], "2024-01-15T15:29:09.600"
         )
-    
+
     def test_to_astropy_time(self):
-        
+
         # initialize AstroPy and AbsoluteDate objects
         astropy_time = Astropy_Time(
             "2025-03-17T12:00:00", format="isot", scale="utc"
@@ -120,7 +118,7 @@ class TestAbsoluteDate(unittest.TestCase):
 
         # Assert that the converted time matches the original Astropy Time
         self.assertEqual(converted_time, astropy_time)
-    
+
     def test_to_skyfield_time(self):
         absolute_date = AbsoluteDate.from_dict(
             {

--- a/tests/test_time.py
+++ b/tests/test_time.py
@@ -11,58 +11,61 @@ class TestAbsoluteDate(unittest.TestCase):
     """Test the AbsoluteDate class."""
 
     def test_from_dict_gregorian(self):
+        # validation with data in the SPICE help file
+        # https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/cspice/str2et_c.html
         dict_in = {
             "time_format": "Gregorian_Date",
-            "year": 2025,
-            "month": 3,
-            "day": 10,
-            "hour": 14,
-            "minute": 30,
-            "second": 0.0,
+            "calendar_date": "2017-07-14T19:46:00.0",
             "time_scale": "utc",
         }
         absolute_date = AbsoluteDate.from_dict(dict_in)
-        self.assertEqual(
-            absolute_date.astropy_time.iso, "2025-03-10 14:30:00.000"
+        # results may differ across platforms and kernels used
+        self.assertAlmostEqual(
+            absolute_date.ephemeris_time, 553333629.183727, places=6
         )
 
     def test_from_dict_julian(self):
+        # validation with data in the SPICE help file
+        # https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/cspice/str2et_c.html
         dict_in = {
             "time_format": "Julian_Date",
-            "jd": 2457081.10417,
+            "jd": 2457949.323611111, # 2017 July 14 19:46:0.0
             "time_scale": "utc",
         }
         absolute_date = AbsoluteDate.from_dict(dict_in)
         self.assertAlmostEqual(
-            absolute_date.astropy_time.jd, 2457081.10417, places=5
+            absolute_date.ephemeris_time, 553333629.183727, places=4
         )
 
     def test_to_dict_gregorian(self):
-        astropy_time = Astropy_Time(
-            "2025-03-10T14:30:00", format="isot", scale="utc"
-        )
-        absolute_date = AbsoluteDate(astropy_time)
-        dict_out = absolute_date.to_dict("Gregorian_Date")
+        absolute_date = AbsoluteDate.from_dict(
+                        {
+                            "time_format": "Gregorian_Date",
+                            "calendar_date": "2025-03-10T14:30:0",
+                            "time_scale": "utc",
+                        }
+                    )
+        dict_out = absolute_date.to_dict("Gregorian_Date", "UTC")
         expected_dict = {
             "time_format": "GREGORIAN_DATE",
-            "year": 2025,
-            "month": 3,
-            "day": 10,
-            "hour": 14,
-            "minute": 30,
-            "second": 0,
-            "time_scale": "utc",
+            "calendar_date": "2025-03-10T14:30:00.000",
+            "time_scale": "UTC",
         }
         self.assertEqual(dict_out, expected_dict)
 
     def test_to_dict_julian(self):
-        astropy_time = Astropy_Time(2457081.10417, format="jd", scale="utc")
-        absolute_date = AbsoluteDate(astropy_time)
+        absolute_date = AbsoluteDate.from_dict(
+                        {
+                            "time_format": "Julian_Date",
+                            "jd": 2457081.10417,
+                            "time_scale": "utc",
+                        }
+                    )
         dict_out = absolute_date.to_dict("Julian_Date")
         expected_dict = {
             "time_format": "JULIAN_DATE",
             "jd": 2457081.10417,
-            "time_scale": "utc",
+            "time_scale": "UTC",
         }
         self.assertEqual(dict_out, expected_dict)
 
@@ -70,18 +73,16 @@ class TestAbsoluteDate(unittest.TestCase):
         # Initialize with Gregorian date
         dict_in = {
             "time_format": "GREGORIAN_DATE",
-            "year": 2025,
-            "month": 3,
-            "day": 11,
-            "hour": 1,
-            "minute": 23,
-            "second": 37.0,
-            "time_scale": "ut1",
+            "calendar_date": "2025-03-11T01:23:37.0",
+            "time_scale": "utc",
         }
         absolute_date = AbsoluteDate.from_dict(dict_in)
+        absolute_date_jd = absolute_date.to_dict("Julian_Date")
         # Validation data from: https://aa.usno.navy.mil/data/JulianDate
+        # Since both dates are in UTC, it may not matter that the USNO 
+        # website specifies the time scale as UT1. 
         self.assertAlmostEqual(
-            absolute_date.astropy_time.jd, 2460745.558067, places=5
+            absolute_date_jd["jd"], 2460745.558067, places=5
         )
 
     def test_julian_to_gregorian(self):
@@ -89,47 +90,44 @@ class TestAbsoluteDate(unittest.TestCase):
         dict_in = {
             "time_format": "Julian_Date",
             "jd": 2460325.145250,
-            "time_scale": "ut1",
+            "time_scale": "utc",
         }
         absolute_date = AbsoluteDate.from_dict(dict_in)
+        absolute_date_gregorian = absolute_date.to_dict("Gregorian_Date", "UTC")
         # Validation data from: https://aa.usno.navy.mil/data/JulianDate
+        # Since both dates are in UTC, it may not matter that the USNO 
+        # website specifies the time scale as UT1. 
         self.assertEqual(
-            absolute_date.astropy_time.iso, "2024-01-15 15:29:09.600"
+            absolute_date_gregorian["calendar_date"], "2024-01-15T15:29:09.600"
         )
-
-    def test_equality_operator(self):
-        date1 = AbsoluteDate(
-            Astropy_Time("2025-03-17T12:00:00", format="isot", scale="utc")
-        )
-        date2 = AbsoluteDate(
-            Astropy_Time("2025-03-17T12:00:00", format="isot", scale="utc")
-        )
-        date3 = AbsoluteDate(
-            Astropy_Time("2025-03-18T12:00:00", format="isot", scale="utc")
-        )
-
-        # Test equality
-        self.assertTrue(date1 == date2)
-        self.assertFalse(date1 == date3)
-
-        # Test comparison with a non-AbsoluteDate object
-        self.assertFalse(date1 == "not an AbsoluteDate")
-
+    
     def test_to_astropy_time(self):
+        
+        # initialize AstroPy and AbsoluteDate objects
         astropy_time = Astropy_Time(
             "2025-03-17T12:00:00", format="isot", scale="utc"
         )
-        absolute_date = AbsoluteDate(astropy_time)
+        absolute_date = AbsoluteDate.from_dict(
+            {
+                "time_format": "Gregorian_Date",
+                "calendar_date": "2025-03-17T12:00:00",
+                "time_scale": "utc",
+            }
+        )
 
         # Convert to Astropy Time
         converted_time = absolute_date.to_astropy_time()
 
         # Assert that the converted time matches the original Astropy Time
         self.assertEqual(converted_time, astropy_time)
-
+    
     def test_to_skyfield_time(self):
-        absolute_date = AbsoluteDate(
-            Astropy_Time("2025-03-17T12:00:00", format="isot", scale="utc")
+        absolute_date = AbsoluteDate.from_dict(
+            {
+                "time_format": "Gregorian_Date",
+                "calendar_date": "2025-03-17T12:00:00",
+                "time_scale": "utc",
+            }
         )
         # Convert to Skyfield Time
         skyfield_time = absolute_date.to_skyfield_time()
@@ -139,6 +137,38 @@ class TestAbsoluteDate(unittest.TestCase):
             skyfield_time.utc_strftime(format="%Y-%m-%d %H:%M:%S UTC"),
             "2025-03-17 12:00:00 UTC",
         )
+
+    def test_equality_operator(self):
+        date1 = AbsoluteDate.from_dict(
+            {
+                "time_format": "Gregorian_Date",
+                "calendar_date": "2025-03-17T12:00:00",
+                "time_scale": "utc",
+            }
+        )
+        # Create another AbsoluteDate object with the same date
+        date2 = AbsoluteDate.from_dict(
+            {
+                "time_format": "Gregorian_Date",
+                "calendar_date": "2025-03-17T12:00:00",
+                "time_scale": "utc",
+            }
+        )
+        # Create a different AbsoluteDate object
+        date3 = AbsoluteDate.from_dict(
+            {
+                "time_format": "Gregorian_Date",
+                "calendar_date": "2025-03-18T12:00:00",
+                "time_scale": "utc",
+            }
+        )
+
+        # Test equality
+        self.assertTrue(date1 == date2)
+        self.assertFalse(date1 == date3)
+
+        # Test comparison with a non-AbsoluteDate object
+        self.assertFalse(date1 == "not an AbsoluteDate")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- Enhanced `Cartesian3DPosition`, `Cartesian3DVelocity`, `CartesianState` classes to support optional frame input in `to_dict`, `to_list` functions as a `ReferenceFrame` enum, string or None.
- Revised `AbsoluteDate` class to utilize SPICE (`spiceypy`) for handling Gregorian and Julian date formats with UTC time-scale.
- Simplified Gregorian date input to accept a single ISO 8601 type string as calendar-date time input, instead of separate components (year, month, etc.).