### PR TITLE
Added reference frame capabilities.

### DIFF
--- a/eosimutils/attitude.py
+++ b/eosimutils/attitude.py
@@ -4,8 +4,8 @@ import spiceypy as spice
 
 from typing import Optional, Union, Dict, Any
 import numpy as np
-from scipy.spatial.transform import Rotation
-from scipy.spatial.transform import Slerp
+from scipy.spatial.transform import Rotation as Scipy_Rotation
+from scipy.spatial.transform import Slerp as Scipy_Slerp
 
 from .frames import ReferenceFrame
 from .time import AbsoluteDate, AbsoluteDateArray
@@ -16,21 +16,31 @@ class Attitude:
     """
     Base class for attitude representations.
 
-    Subclasses must implement `at(t)` to return (Rotation, angular_velocity).
+    Subclasses must implement `at(t)` to return (Scipy_Rotation, angular_velocity). Note that
+    Scipy Rotation objects use the scalar-last convention for quaternions. Counterclockwise
+    rotations are positive.
 
     Provides `transform(state, t)` to apply rotation and angular velocity to 6D state vectors.
     """
 
+    def __init__(self, from_frame: ReferenceFrame, to_frame: ReferenceFrame):
+        self.from_frame = from_frame
+        self.to_frame = to_frame
+
     def at(
-        self, t: Union[AbsoluteDate, AbsoluteDateArray]
-    ) -> tuple[Rotation, np.ndarray]:
+        self, t: Union[AbsoluteDate, AbsoluteDateArray, None]
+    ) -> tuple[Scipy_Rotation, np.ndarray]:
         """
         Return (rotation, angular_velocity) at the given time(s).
+
+        The angular velocity is the angular velocity of from_frame w.r.t. to_frame.
+
+        Time can also be None for case of constant attitude.
 
         Args:
             t: AbsoluteDate or AbsoluteDateArray.
         Returns:
-            Tuple[Rotation, np.ndarray]: Rotation and angular velocity vector(s).
+            Tuple[Scipy_Rotation, np.ndarray]: Scipy_Rotation and angular velocity vector(s).
         """
         raise NotImplementedError
 
@@ -62,30 +72,46 @@ class Attitude:
         new_vel = rot.apply(vel) + np.cross(w, new_pos)
         return np.hstack([new_pos, new_vel])
 
+    def inverse(self) -> "Attitude":
+        """
+        Return the inverse of the current attitude.
+
+        Returns:
+            Attitude: A new Attitude object with inverted frames and rotations.
+        """
+        raise NotImplementedError
+
 
 class ConstantAttitude(Attitude):
     """
     Represents a time-invariant attitude using a single constant rotation.
 
     Attributes:
-        rotation (Rotation): The constant orientation.
-        base (ReferenceFrame): The base reference frame.
+        rotation (Scipy_Rotation): The constant orientation.
+        from_frame (ReferenceFrame): Source frame for the rotation.
+        to_frame (ReferenceFrame): Target frame for the rotation.
     """
 
-    def __init__(self, rotation: Rotation, base: ReferenceFrame):
+    def __init__(
+        self,
+        rotation: Scipy_Rotation,
+        from_frame: ReferenceFrame,
+        to_frame: ReferenceFrame,
+    ):
         """
         Initialize a ConstantAttitude.
 
         Args:
-            rotation (Rotation): A single scipy Rotation object.
-            base (ReferenceFrame): The base frame of the rotation.
+            rotation (Scipy_Rotation): A single Scipy_Rotation object.
+            from_frame (ReferenceFrame): The source frame of the rotation.
+            to_frame (ReferenceFrame): The target frame of the rotation.
         """
+        super().__init__(from_frame, to_frame)
         self.rotation = rotation
-        self.base = base
 
     def at(
-        self, t: Union[AbsoluteDate, AbsoluteDateArray]
-    ) -> tuple[Rotation, np.ndarray]:
+        self, t: Union[AbsoluteDate, AbsoluteDateArray, None]
+    ) -> tuple[Scipy_Rotation, np.ndarray]:
         """
         Evaluate the attitude at the given time(s). Always returns the same rotation.
 
@@ -93,15 +119,15 @@ class ConstantAttitude(Attitude):
             t (AbsoluteDate or AbsoluteDateArray): Input time(s).
 
         Returns:
-            Tuple[Rotation, np.ndarray]: The constant rotation and a zero angular velocity vector.
+            Tuple[Scipy_Rotation, np.ndarray]: The rotation and zero angular velocity vector.
         """
-        if isinstance(t, AbsoluteDate):
+        if isinstance(t, (AbsoluteDate, type(None))):
             return self.rotation, np.zeros(3)
         elif isinstance(t, AbsoluteDateArray):
             n = len(t.ephemeris_time)
-            return Rotation.from_quat([self.rotation.as_quat()] * n), np.zeros(
-                (n, 3)
-            )
+            return Scipy_Rotation.from_quat(
+                [self.rotation.as_quat()] * n
+            ), np.zeros((n, 3))
         else:
             raise TypeError("t must be AbsoluteDate or AbsoluteDateArray")
 
@@ -115,8 +141,10 @@ class ConstantAttitude(Attitude):
                 # - If "rotations_type" is "quaternion": List of 4 values [x, y, z, w]
                 # - If "rotations_type" is "euler": List of 3 values (Euler angles)
             "rotations_type": str,  # "quaternion" or "euler"
-            "euler_order": str (optional),  # Only if rotations_type is "euler", default is "xyz"
-            "base": str,  # Name of the base reference frame
+            "euler_order": str (optional),  # Order (e.g., "xyz"), if "rotations_type" is "euler".
+                Use lowercase for intrinsic rotations, otherwise extrinsic. Defaults to "xyz".
+            "from": str,  # Name of the source reference frame
+            "to": str,  # Name of the target reference frame
         }
 
         Args:
@@ -135,7 +163,8 @@ class ConstantAttitude(Attitude):
         result = {
             "rotations": rotations,
             "rotations_type": rotations_type,
-            "base": self.base.to_string(),
+            "from": self.from_frame.to_string(),
+            "to": self.to_frame.to_string(),
         }
         if rotations_type == "euler":
             result["euler_order"] = "xyz"
@@ -152,8 +181,10 @@ class ConstantAttitude(Attitude):
                 # - If "rotations_type" is "quaternion": List of 4 values [x, y, z, w]
                 # - If "rotations_type" is "euler": List of 3 values (Euler angles)
             "rotations_type": str,  # "quaternion" (default) or "euler"
-            "euler_order": str (optional),  # Required if rotations_type is "euler"
-            "base": str,  # Name of the base reference frame
+            "euler_order": str (optional),  # Order (e.g., "xyz"), if "rotations_type" is "euler".
+                Use lowercase for intrinsic rotations, otherwise extrinsic.
+            "from": str,  # Name of the source reference frame
+            "to": str,  # Name of the target reference frame
         }
 
         Args:
@@ -168,19 +199,31 @@ class ConstantAttitude(Attitude):
         rotations_type = data.get("rotations_type", "quaternion")
 
         if rotations_type == "quaternion":
-            rotation = Rotation.from_quat(data["rotations"])
+            rotation = Scipy_Rotation.from_quat(data["rotations"])
         elif rotations_type == "euler":
             order = data.get("euler_order")
             if not order:
                 raise ValueError(
                     "Missing required 'euler_order' for euler rotations."
                 )
-            rotation = Rotation.from_euler(order, data["rotations"])
+            rotation = Scipy_Rotation.from_euler(order, data["rotations"])
         else:
             raise ValueError(f"Unsupported rotations_type: {rotations_type}")
 
-        base = ReferenceFrame.get(data["base"])
-        return cls(rotation, base)
+        from_frame = ReferenceFrame.get(data["from"])
+        to_frame = ReferenceFrame.get(data["to"])
+        return cls(rotation, from_frame, to_frame)
+
+    def inverse(self) -> "ConstantAttitude":
+        """
+        Return the inverse of the current constant attitude.
+
+        Returns:
+            ConstantAttitude: A new ConstantAttitude object with inverted rotation and frames.
+        """
+        return ConstantAttitude(
+            self.rotation.inv(), self.to_frame, self.from_frame
+        )
 
 
 class SpiceAttitude(Attitude):
@@ -198,13 +241,9 @@ class SpiceAttitude(Attitude):
         ReferenceFrame.ITRF: "ITRF93",
     }
 
-    def __init__(self, from_frame: ReferenceFrame, to_frame: ReferenceFrame):
-        self.from_frame = from_frame
-        self.to_frame = to_frame
-
     def at(
         self, t: Union[AbsoluteDate, AbsoluteDateArray]
-    ) -> tuple[Rotation, np.ndarray]:
+    ) -> tuple[Scipy_Rotation, np.ndarray]:
         """
         Evaluate the SPICE attitude and angular velocity at the given time(s).
 
@@ -212,7 +251,7 @@ class SpiceAttitude(Attitude):
             t (AbsoluteDate or AbsoluteDateArray): Time(s) for evaluation.
 
         Returns:
-            Tuple[Rotation, np.ndarray]: Rotation(s) and angular velocity vector(s).
+            Tuple[Scipy_Rotation, np.ndarray]: Scipy_Rotation(s) and angular velocity vector(s).
         """
         spice_from = self.spice_names[self.from_frame]
         spice_to = self.spice_names[self.to_frame]
@@ -222,7 +261,7 @@ class SpiceAttitude(Attitude):
                 spice_from, spice_to, t.to_spice_ephemeris_time()
             )
             r_mat, w = spice.xf2rav(sxform)
-            return Rotation.from_matrix(r_mat), np.array(w)
+            return Scipy_Rotation.from_matrix(r_mat), np.array(w)
         elif isinstance(t, AbsoluteDateArray):
             et_array = t.ephemeris_time
             r_list = []
@@ -232,7 +271,9 @@ class SpiceAttitude(Attitude):
                 r_mat, w = spice.xf2rav(sxform)
                 r_list.append(r_mat)
                 w_list.append(w)
-            return Rotation.from_matrix(np.array(r_list)), np.array(w_list)
+            return Scipy_Rotation.from_matrix(np.array(r_list)), np.array(
+                w_list
+            )
         else:
             raise TypeError("t must be AbsoluteDate or AbsoluteDateArray")
 
@@ -263,23 +304,34 @@ class SpiceAttitude(Attitude):
         to_frame = ReferenceFrame.get(data["to"])
         return cls(from_frame, to_frame)
 
+    def inverse(self) -> "SpiceAttitude":
+        """
+        Return the inverse of the current SPICE attitude.
+
+        Returns:
+            SpiceAttitude: A new SpiceAttitude object with inverted frames.
+        """
+        return SpiceAttitude(self.to_frame, self.from_frame)
+
 
 class AttitudeSeries(Attitude):
     """
-    Represents orientation data as a timeseries using scipy Rotation objects.
+    Represents orientation data as a timeseries using scipy Scipy_Rotation objects.
 
     Attributes:
         time (AbsoluteDateArray): Time samples.
-        rotations (Rotation): Orientation at each time sample.
-        base (ReferenceFrame): Base reference frame.
+        rotations (Scipy_Rotation): Orientation at each time sample.
+        from_frame (ReferenceFrame): Source frame for the rotations.
+        to_frame (ReferenceFrame): Target frame for the rotations.
         angular_velocity (np.ndarray): Angular velocity vectors (Nx3).
     """
 
     def __init__(
         self,
         time: AbsoluteDateArray,
-        rotations: Rotation,
-        base: ReferenceFrame,
+        rotations: Scipy_Rotation,
+        from_frame: ReferenceFrame,
+        to_frame: ReferenceFrame,
         angular_velocity: Optional[np.ndarray] = None,
     ):
         """
@@ -287,8 +339,9 @@ class AttitudeSeries(Attitude):
 
         Args:
             time (AbsoluteDateArray): Array of time points.
-            rotations (Rotation): Rotation object containing N orientations.
-            base (ReferenceFrame): Static base reference frame.
+            rotations (Scipy_Rotation): Scipy_Rotation object containing N orientations.
+            from_frame (ReferenceFrame): Source frame for the rotations.
+            to_frame (ReferenceFrame): Target frame for the rotations.
             angular_velocity (np.ndarray, optional): Angular velocity vectors (Nx3).
                 If None, computed automatically from rotations using finite difference.
 
@@ -299,9 +352,9 @@ class AttitudeSeries(Attitude):
         if len(rotations) != len(time.ephemeris_time):
             raise ValueError("rotations and time must have the same length.")
 
+        super().__init__(from_frame, to_frame)
         self.time = time
         self.rotations = rotations
-        self.base = base
 
         if angular_velocity is not None:
             if angular_velocity.shape != (len(time.ephemeris_time), 3):
@@ -361,7 +414,9 @@ class AttitudeSeries(Attitude):
 
         return omega
 
-    def to_dict(self, rotations_type: str = "euler") -> Dict[str, Any]:
+    def to_dict(
+        self, rotations_type: str = "euler", euler_order: str = "xyz"
+    ) -> Dict[str, Any]:
         """
         Serialize this AttitudeSeries into a dictionary.
 
@@ -373,8 +428,10 @@ class AttitudeSeries(Attitude):
                                 #   where each quaternion is [x, y, z, w] (scalar-last format).
                                 # - If "rotations_type" is "euler": List of Euler angles (Nx3)
             "rotations_type": str,  # Type of rotations: "quaternion" or "euler"
-            "euler_order": str (optional),  # Order (e.g., "xyz"), if "rotations_type" is "euler"
-            "base": str,  # Base reference frame as a string identifier
+            "euler_order": str (optional),  # Order (e.g., "xyz"), if "rotations_type" is "euler".
+                Use lowercase for intrinsic rotations, otherwise extrinsic.
+            "from": str,  # Source reference frame as a string identifier
+            "to": str,  # Target reference frame as a string identifier
             "angular_velocity": list  # List of angular velocity vectors (Nx3)
         }
 
@@ -388,9 +445,7 @@ class AttitudeSeries(Attitude):
         if rotations_type == "quaternion":
             rotations = self.rotations.as_quat().tolist()
         elif rotations_type == "euler":
-            rotations = self.rotations.as_euler(
-                "xyz"
-            ).tolist()  # Default to "xyz" order
+            rotations = self.rotations.as_euler(euler_order).tolist()
         else:
             raise ValueError(f"Unsupported rotations_type: {rotations_type}")
 
@@ -398,14 +453,13 @@ class AttitudeSeries(Attitude):
             "time": self.time.to_dict(),
             "rotations": rotations,
             "rotations_type": rotations_type,
-            "base": self.base.to_string(),
+            "from": self.from_frame.to_string(),
+            "to": self.to_frame.to_string(),
             "angular_velocity": self.angular_velocity.tolist(),
         }
 
         if rotations_type == "euler":
-            result["euler_order"] = (
-                "xyz"  # Include the Euler order if applicable
-            )
+            result["euler_order"] = euler_order
 
         return result
 
@@ -422,8 +476,11 @@ class AttitudeSeries(Attitude):
                                 #   where each quaternion is [x, y, z, w] (scalar-last format).
                                 # - If "rotations_type" is "euler": List of Euler angles (Nx3)
             "rotations_type": str,  # Type of rotations: "quaternion" (default) or "euler"
-            "euler_order": str (optional),  # Order (e.g., "xyz"), if "rotations_type" is "euler"
-            "base": str,  # Base reference frame as a string identifier
+            "euler_order": str (optional),  # Order (e.g., "xyz"), if "rotations_type" is "euler".
+                Use lowercase for intrinsic rotations, otherwise extrinsic.
+            If coordinate axes are lowercase, uses intrinsic rotations, otherwise extrinsic.
+            "from": str,  # Source reference frame as a string identifier
+            "to": str,  # Target reference frame as a string identifier
             "angular_velocity": list (optional)  # List of angular velocity vectors (Nx3)
         }
 
@@ -440,31 +497,32 @@ class AttitudeSeries(Attitude):
         rotations_type = data.get("rotations_type", "quaternion")
 
         if rotations_type == "quaternion":
-            rotations = Rotation.from_quat(data["rotations"])
+            rotations = Scipy_Rotation.from_quat(data["rotations"])
         elif rotations_type == "euler":
             euler_order = data.get("euler_order")
             if not euler_order:
                 raise ValueError(
                     "euler_order is required when rotations_type is 'euler'."
                 )
-            rotations = Rotation.from_euler(euler_order, data["rotations"])
+            rotations = Scipy_Rotation.from_euler(
+                euler_order, data["rotations"]
+            )
         else:
             raise ValueError(f"Unsupported rotations_type: {rotations_type}")
 
-        base = ReferenceFrame.get(
-            data["base"]
-        )  # Deserialize base as ReferenceFrame
+        from_frame = ReferenceFrame.get(data["from"])
+        to_frame = ReferenceFrame.get(data["to"])
 
         angular_velocity = (
             np.array(data["angular_velocity"])
             if "angular_velocity" in data
             else None
         )
-        return cls(time, rotations, base, angular_velocity)
+        return cls(time, rotations, from_frame, to_frame, angular_velocity)
 
     def at(
         self, t: Union[AbsoluteDate, AbsoluteDateArray]
-    ) -> tuple[Rotation, np.ndarray]:
+    ) -> tuple[Scipy_Rotation, np.ndarray]:
         """
         Get the interpolated rotations and angular velocity at the specified time(s).
 
@@ -472,8 +530,8 @@ class AttitudeSeries(Attitude):
             new_dates (AbsoluteDate or AbsoluteDateArray): Time(s) at which to evaluate.
 
         Returns:
-            - If AbsoluteDate: a tuple (Rotation, angular_velocity_vector).
-            - If AbsoluteDateArray: a tuple (Rotation, ndarray of angular velocities).
+            - If AbsoluteDate: a tuple (Scipy_Rotation, angular_velocity_vector).
+            - If AbsoluteDateArray: a tuple (Scipy_Rotation, ndarray of angular velocities).
         """
         if isinstance(t, AbsoluteDate):
             new_et = np.array([t.ephemeris_time])
@@ -486,7 +544,9 @@ class AttitudeSeries(Attitude):
                 "new_dates must be an AbsoluteDate or AbsoluteDateArray."
             )
 
-    def _resample(self, new_et: np.ndarray) -> tuple[Rotation, np.ndarray]:
+    def _resample(
+        self, new_et: np.ndarray
+    ) -> tuple[Scipy_Rotation, np.ndarray]:
         """
         Internal method to perform SLERP and angular velocity assignment.
 
@@ -494,9 +554,9 @@ class AttitudeSeries(Attitude):
             new_et (np.ndarray): New ephemeris times (1D array).
 
         Returns:
-            Tuple[Rotation, np.ndarray]: Interpolated rotations and angular velocity.
+            Tuple[Scipy_Rotation, np.ndarray]: Interpolated rotations and angular velocity.
         """
-        slerp = Slerp(self.time.ephemeris_time, self.rotations)
+        slerp = Scipy_Slerp(self.time.ephemeris_time, self.rotations)
         new_rotations = slerp(new_et)
 
         indices = (
@@ -523,7 +583,8 @@ class AttitudeSeries(Attitude):
         return AttitudeSeries(
             time=new_time,
             rotations=new_rotations,
-            base=self.base,
+            from_frame=self.from_frame,
+            to_frame=self.to_frame,
             angular_velocity=new_angular_velocity,
         )
 
@@ -532,9 +593,10 @@ class AttitudeSeries(Attitude):
         cls,
         start_time: "AbsoluteDate",
         duration: float,
-        initial_rotation: Rotation,
+        initial_rotation: Scipy_Rotation,
         angular_velocity: np.ndarray,
-        base: ReferenceFrame,
+        from_frame: ReferenceFrame,
+        to_frame: ReferenceFrame,
     ) -> "AttitudeSeries":
         """
         Create an AttitudeSeries with a constant angular velocity.
@@ -542,12 +604,10 @@ class AttitudeSeries(Attitude):
         Args:
             start_time (AbsoluteDate): The starting time of the series.
             duration (float): Duration of the series in seconds.
-            initial_rotation (Rotation): Initial orientation as a scipy Rotation object.
+            initial_rotation (Scipy_Rotation): Initial orientation as a scipy Scipy_Rotation object.
             angular_velocity (np.ndarray): Constant angular velocity vector (3D) in rad/s.
-            base (ReferenceFrame): Base reference frame.
-
-        Returns:
-            AttitudeSeries: A new AttitudeSeries object.
+            from_frame (ReferenceFrame): Source frame for the rotations.
+            to_frame (ReferenceFrame): Target frame for the rotations.
         """
         if angular_velocity.shape != (3,):
             raise ValueError("Angular velocity must be a 3D vector.")
@@ -562,8 +622,8 @@ class AttitudeSeries(Attitude):
         time_array = AbsoluteDateArray(time_samples)
 
         # Compute rotations at start and stop times
-        delta_rotation = Rotation.from_rotvec(angular_velocity * duration)
-        rotations = Rotation.from_quat(
+        delta_rotation = Scipy_Rotation.from_rotvec(angular_velocity * duration)
+        rotations = Scipy_Rotation.from_quat(
             [
                 initial_rotation.as_quat(),
                 (initial_rotation * delta_rotation).as_quat(),
@@ -574,7 +634,8 @@ class AttitudeSeries(Attitude):
         return cls(
             time=time_array,
             rotations=rotations,
-            base=base,
+            from_frame=from_frame,
+            to_frame=to_frame,
             angular_velocity=np.tile(angular_velocity, (2, 1)),
         )
 
@@ -582,6 +643,14 @@ class AttitudeSeries(Attitude):
     def get_lvlh(cls, state: StateSeries) -> "AttitudeSeries":
         """
         Compute an LVLH AttitudeSeries from a StateSeries in an inertial reference frame.
+
+        The axes are constructed as follows:
+
+            - Z-axis (Local Vertical): negative unit position vector (-r/|r|).
+            - Y-axis (Cross-track): negative unit angular momentum vector (-h/|h|, where h = r × v).
+            - X-axis (Local Horizontal): cross product of Y and Z axes (x = y × z).
+
+        Reference: https://sanaregistry.org/r/orbit_relative_reference_frames/ (LVLH_ROTATING)
 
         Args:
             state (StateSeries): Trajectory in an inertial frame.
@@ -601,25 +670,36 @@ class AttitudeSeries(Attitude):
         pos = state.data[0]  # shape (N,3)
         vel = state.data[1]  # shape (N,3)
 
-        # Build direction cosine matrices
         r_mats = []
         for r, v in zip(pos, vel):
             r_norm = np.linalg.norm(r)
-            if r_norm == 0:
-                raise ValueError(
-                    "Position vector has zero norm; cannot define LVLH axes"
-                )
-            x_hat = r / r_norm
+            z_hat = -r / r_norm  # Local vertical: -r/|r|
             h = np.cross(r, v)
             h_norm = np.linalg.norm(h)
-            if h_norm == 0:
-                raise ValueError(
-                    "Angular momentum vector has zero norm; cannot define LVLH axes"
-                )
-            z_hat = h / h_norm
-            y_hat = np.cross(z_hat, x_hat)
+            y_hat = -h / h_norm  # Cross-track:-h/|h|
+            x_hat = np.cross(y_hat, z_hat)  # Local horizontal: y × z
             # Rows are LVLH axes in inertial coordinates
             r_mats.append(np.vstack([x_hat, y_hat, z_hat]))
 
-        rotations = Rotation.from_matrix(np.array(r_mats))
-        return cls(time=state.time, rotations=rotations, base=state.frame)
+        rotations = Scipy_Rotation.from_matrix(np.array(r_mats))
+        return cls(
+            time=state.time,
+            rotations=rotations,
+            from_frame=state.frame,
+            to_frame=ReferenceFrame.LVLH,
+        )
+
+    def inverse(self) -> "AttitudeSeries":
+        """
+        Return the inverse of the current attitude series.
+
+        Returns:
+            AttitudeSeries: A new AttitudeSeries object with inverted rotations and frames.
+        """
+        return AttitudeSeries(
+            time=self.time,
+            rotations=self.rotations.inv(),
+            from_frame=self.to_frame,
+            to_frame=self.from_frame,
+            angular_velocity=-self.angular_velocity,
+        )

--- a/eosimutils/attitude.py
+++ b/eosimutils/attitude.py
@@ -1,0 +1,625 @@
+"""Module for handling constant and timeseries attitude data."""
+
+import spiceypy as spice
+
+from typing import Optional, Union, Dict, Any
+import numpy as np
+from scipy.spatial.transform import Rotation
+from scipy.spatial.transform import Slerp
+
+from .frames import ReferenceFrame
+from .time import AbsoluteDate, AbsoluteDateArray
+from .trajectory import StateSeries
+
+
+class Attitude:
+    """
+    Base class for attitude representations.
+
+    Subclasses must implement `at(t)` to return (Rotation, angular_velocity).
+
+    Provides `transform(state, t)` to apply rotation and angular velocity to 6D state vectors.
+    """
+
+    def at(
+        self, t: Union[AbsoluteDate, AbsoluteDateArray]
+    ) -> tuple[Rotation, np.ndarray]:
+        """
+        Return (rotation, angular_velocity) at the given time(s).
+
+        Args:
+            t: AbsoluteDate or AbsoluteDateArray.
+        Returns:
+            Tuple[Rotation, np.ndarray]: Rotation and angular velocity vector(s).
+        """
+        raise NotImplementedError
+
+    def transform(
+        self, state: np.ndarray, t: Union[AbsoluteDate, AbsoluteDateArray]
+    ) -> np.ndarray:
+        """
+        Transform a 6D state vector or array of state vectors [pos(3), vel(3)] at given time(s).
+
+        Args:
+            state: shape (6,) or (N,6).
+            t: AbsoluteDate or AbsoluteDateArray of matching length if state is (N,6).
+
+        Returns:
+            Transformed state array of same shape.
+        """
+        rot, w = self.at(t)
+        # single time
+        if isinstance(t, AbsoluteDate):
+            pos = state[:3]
+            vel = state[3:]
+            new_pos = rot.apply(pos)
+            new_vel = rot.apply(vel) + np.cross(w, new_pos)
+            return np.concatenate([new_pos, new_vel])
+        # multiple times
+        pos = state[:, :3]
+        vel = state[:, 3:]
+        new_pos = rot.apply(pos)
+        new_vel = rot.apply(vel) + np.cross(w, new_pos)
+        return np.hstack([new_pos, new_vel])
+
+
+class ConstantAttitude(Attitude):
+    """
+    Represents a time-invariant attitude using a single constant rotation.
+
+    Attributes:
+        rotation (Rotation): The constant orientation.
+        base (ReferenceFrame): The base reference frame.
+    """
+
+    def __init__(self, rotation: Rotation, base: ReferenceFrame):
+        """
+        Initialize a ConstantAttitude.
+
+        Args:
+            rotation (Rotation): A single scipy Rotation object.
+            base (ReferenceFrame): The base frame of the rotation.
+        """
+        self.rotation = rotation
+        self.base = base
+
+    def at(
+        self, t: Union[AbsoluteDate, AbsoluteDateArray]
+    ) -> tuple[Rotation, np.ndarray]:
+        """
+        Evaluate the attitude at the given time(s). Always returns the same rotation.
+
+        Args:
+            t (AbsoluteDate or AbsoluteDateArray): Input time(s).
+
+        Returns:
+            Tuple[Rotation, np.ndarray]: The constant rotation and a zero angular velocity vector.
+        """
+        if isinstance(t, AbsoluteDate):
+            return self.rotation, np.zeros(3)
+        elif isinstance(t, AbsoluteDateArray):
+            n = len(t.ephemeris_time)
+            return Rotation.from_quat([self.rotation.as_quat()] * n), np.zeros(
+                (n, 3)
+            )
+        else:
+            raise TypeError("t must be AbsoluteDate or AbsoluteDateArray")
+
+    def to_dict(self, rotations_type: str = "euler") -> Dict[str, Any]:
+        """
+        Serialize the ConstantAttitude to a dictionary.
+
+        The dictionary format is as follows:
+        {
+            "rotations": list,
+                # - If "rotations_type" is "quaternion": List of 4 values [x, y, z, w]
+                # - If "rotations_type" is "euler": List of 3 values (Euler angles)
+            "rotations_type": str,  # "quaternion" or "euler"
+            "euler_order": str (optional),  # Only if rotations_type is "euler", default is "xyz"
+            "base": str,  # Name of the base reference frame
+        }
+
+        Args:
+            rotations_type (str): Either "quaternion" or "euler" (default: "euler").
+
+        Returns:
+            dict: Serialized ConstantAttitude.
+        """
+        if rotations_type == "quaternion":
+            rotations = self.rotation.as_quat()
+        elif rotations_type == "euler":
+            rotations = self.rotation.as_euler("xyz").tolist()
+        else:
+            raise ValueError(f"Unsupported rotations_type: {rotations_type}")
+
+        result = {
+            "rotations": rotations,
+            "rotations_type": rotations_type,
+            "base": self.base.to_string(),
+        }
+        if rotations_type == "euler":
+            result["euler_order"] = "xyz"
+        return result
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "ConstantAttitude":
+        """
+        Construct a ConstantAttitude from a dictionary.
+
+        The expected dictionary format is:
+        {
+            "rotations": list,
+                # - If "rotations_type" is "quaternion": List of 4 values [x, y, z, w]
+                # - If "rotations_type" is "euler": List of 3 values (Euler angles)
+            "rotations_type": str,  # "quaternion" (default) or "euler"
+            "euler_order": str (optional),  # Required if rotations_type is "euler"
+            "base": str,  # Name of the base reference frame
+        }
+
+        Args:
+            data (dict): Serialized ConstantAttitude dictionary.
+
+        Returns:
+            ConstantAttitude: Reconstructed object.
+
+        Raises:
+            ValueError: If Euler angles are used but no order is specified.
+        """
+        rotations_type = data.get("rotations_type", "quaternion")
+
+        if rotations_type == "quaternion":
+            rotation = Rotation.from_quat(data["rotations"])
+        elif rotations_type == "euler":
+            order = data.get("euler_order")
+            if not order:
+                raise ValueError(
+                    "Missing required 'euler_order' for euler rotations."
+                )
+            rotation = Rotation.from_euler(order, data["rotations"])
+        else:
+            raise ValueError(f"Unsupported rotations_type: {rotations_type}")
+
+        base = ReferenceFrame.get(data["base"])
+        return cls(rotation, base)
+
+
+class SpiceAttitude(Attitude):
+    """
+    Attitude defined using SPICE frame transformations, including angular velocity.
+
+    Attributes:
+        from_frame (ReferenceFrame): Source frame for the SPICE transform.
+        to_frame (ReferenceFrame): Target frame for the SPICE transform.
+    """
+
+    # Map ReferenceFrame to SPICE string names
+    spice_names = {
+        ReferenceFrame.ICRF_EC: "J2000",
+        ReferenceFrame.ITRF: "ITRF93",
+    }
+
+    def __init__(self, from_frame: ReferenceFrame, to_frame: ReferenceFrame):
+        self.from_frame = from_frame
+        self.to_frame = to_frame
+
+    def at(
+        self, t: Union[AbsoluteDate, AbsoluteDateArray]
+    ) -> tuple[Rotation, np.ndarray]:
+        """
+        Evaluate the SPICE attitude and angular velocity at the given time(s).
+
+        Args:
+            t (AbsoluteDate or AbsoluteDateArray): Time(s) for evaluation.
+
+        Returns:
+            Tuple[Rotation, np.ndarray]: Rotation(s) and angular velocity vector(s).
+        """
+        spice_from = self.spice_names[self.from_frame]
+        spice_to = self.spice_names[self.to_frame]
+
+        if isinstance(t, AbsoluteDate):
+            sxform = spice.sxform(
+                spice_from, spice_to, t.to_spice_ephemeris_time()
+            )
+            r_mat, w = spice.xf2rav(sxform)
+            return Rotation.from_matrix(r_mat), np.array(w)
+        elif isinstance(t, AbsoluteDateArray):
+            et_array = t.ephemeris_time
+            r_list = []
+            w_list = []
+            for et in et_array:
+                sxform = spice.sxform(spice_from, spice_to, et)
+                r_mat, w = spice.xf2rav(sxform)
+                r_list.append(r_mat)
+                w_list.append(w)
+            return Rotation.from_matrix(np.array(r_list)), np.array(w_list)
+        else:
+            raise TypeError("t must be AbsoluteDate or AbsoluteDateArray")
+
+    def to_dict(self) -> Dict[str, Any]:
+        """
+        Serialize to a dictionary.
+
+        Returns:
+            dict: Dictionary with keys "from" and "to" (ReferenceFrame string names).
+        """
+        return {
+            "from": self.from_frame.to_string(),
+            "to": self.to_frame.to_string(),
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "SpiceAttitude":
+        """
+        Deserialize from a dictionary.
+
+        Args:
+            data (dict): Dictionary with "from" and "to" frame names.
+
+        Returns:
+            SpiceAttitude: Constructed object.
+        """
+        from_frame = ReferenceFrame.get(data["from"])
+        to_frame = ReferenceFrame.get(data["to"])
+        return cls(from_frame, to_frame)
+
+
+class AttitudeSeries(Attitude):
+    """
+    Represents orientation data as a timeseries using scipy Rotation objects.
+
+    Attributes:
+        time (AbsoluteDateArray): Time samples.
+        rotations (Rotation): Orientation at each time sample.
+        base (ReferenceFrame): Base reference frame.
+        angular_velocity (np.ndarray): Angular velocity vectors (Nx3).
+    """
+
+    def __init__(
+        self,
+        time: AbsoluteDateArray,
+        rotations: Rotation,
+        base: ReferenceFrame,
+        angular_velocity: Optional[np.ndarray] = None,
+    ):
+        """
+        Initialize an AttitudeSeries object.
+
+        Args:
+            time (AbsoluteDateArray): Array of time points.
+            rotations (Rotation): Rotation object containing N orientations.
+            base (ReferenceFrame): Static base reference frame.
+            angular_velocity (np.ndarray, optional): Angular velocity vectors (Nx3).
+                If None, computed automatically from rotations using finite difference.
+
+        Raises:
+            ValueError: If rotations length does not match time array length.
+            ValueError: If angular_velocity shape is invalid.
+        """
+        if len(rotations) != len(time.ephemeris_time):
+            raise ValueError("rotations and time must have the same length.")
+
+        self.time = time
+        self.rotations = rotations
+        self.base = base
+
+        if angular_velocity is not None:
+            if angular_velocity.shape != (len(time.ephemeris_time), 3):
+                raise ValueError("Angular_velocity must have shape (N, 3).")
+            self.angular_velocity = angular_velocity
+        else:
+            self.angular_velocity = self._compute_angular_velocity()
+
+    def _compute_angular_velocity(self) -> np.ndarray:
+        """
+        Compute angular velocity vectors from the rotation time series using central finite
+        differences.
+
+        For each internal sample t_i:
+        1. Form the relative rotation from R_{i-1} to R_{i+1}:
+            R_rel = R_{i-1}⁻¹ · R_{i+1}.
+        2. Convert R_rel into its axis–angle vector v = θ·u, where
+            - θ is the magnitude of rotation (in radians),
+            - u is the unit axis of rotation,
+            and SciPy’s `as_rotvec()` returns this v.
+        3. Divide by the elapsed time Δt = t_{i+1} − t_{i−1} to approximate the instantaneous
+        angular velocity:
+            ω(t_i) ≈ v / Δt.
+
+        Because this uses a central difference, the error scales with O(Δt²).  At the endpoints
+        (i=0 and i=N−1) it falls back to simple forward/backward differences,
+        which are only first-order accurate:
+            ω(t₀) ≈ v₀ / (t₁ − t₀),
+            ω(t_{N−1}) ≈ v_{N−1} / (t_{N−1} − t_{N−2}).
+
+        Returns:
+            np.ndarray: An (N×3) array of angular velocity vectors ω(t_i), expressed
+                        in the body-fixed frame at each sample.
+        """
+
+        rotations = self.rotations
+        t = self.time.ephemeris_time
+        n = len(rotations)
+
+        # Prepare output
+        omega = np.zeros((n, 3))
+
+        # 1) central differences for i=1…N-2 in vectorized operation:
+        #    R_rel[i] = R_{i-1}⁻¹ * R_{i+1}  for i=1…N-2
+        r_prev = rotations[:-2]
+        r_next = rotations[2:]
+        r_rel = r_prev.inv() * r_next  # shape (N-2,)
+        v_rel = r_rel.as_rotvec()  # shape (N-2,3)
+        dt = (t[2:] - t[:-2])[:, None]  # shape (N-2,1)
+        omega[1:-1] = v_rel / dt
+
+        # 2) endpoints
+        forward = (rotations[0].inv() * rotations[1]).as_rotvec()
+        backward = (rotations[-2].inv() * rotations[-1]).as_rotvec()
+        omega[0] = forward / (t[1] - t[0])
+        omega[-1] = backward / (t[-1] - t[-2])
+
+        return omega
+
+    def to_dict(self, rotations_type: str = "euler") -> Dict[str, Any]:
+        """
+        Serialize this AttitudeSeries into a dictionary.
+
+        The dictionary format is as follows:
+        {
+            "time": dict,  # Serialized AbsoluteDateArray
+            "rotations": list,  # List of rotations:
+                                # - If "rotations_type" is "quaternion": List of quaternions (Nx4),
+                                #   where each quaternion is [x, y, z, w] (scalar-last format).
+                                # - If "rotations_type" is "euler": List of Euler angles (Nx3)
+            "rotations_type": str,  # Type of rotations: "quaternion" or "euler"
+            "euler_order": str (optional),  # Order (e.g., "xyz"), if "rotations_type" is "euler"
+            "base": str,  # Base reference frame as a string identifier
+            "angular_velocity": list  # List of angular velocity vectors (Nx3)
+        }
+
+        Args:
+            rotations_type (str, optional): The type of rotations to serialize.
+                Options are "quaternion" or "euler". Defaults to "euler".
+
+        Returns:
+            dict: Serialized representation of the AttitudeSeries.
+        """
+        if rotations_type == "quaternion":
+            rotations = self.rotations.as_quat().tolist()
+        elif rotations_type == "euler":
+            rotations = self.rotations.as_euler(
+                "xyz"
+            ).tolist()  # Default to "xyz" order
+        else:
+            raise ValueError(f"Unsupported rotations_type: {rotations_type}")
+
+        result = {
+            "time": self.time.to_dict(),
+            "rotations": rotations,
+            "rotations_type": rotations_type,
+            "base": self.base.to_string(),
+            "angular_velocity": self.angular_velocity.tolist(),
+        }
+
+        if rotations_type == "euler":
+            result["euler_order"] = (
+                "xyz"  # Include the Euler order if applicable
+            )
+
+        return result
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "AttitudeSeries":
+        """
+        Deserialize an AttitudeSeries from a dictionary.
+
+        The expected dictionary format is:
+        {
+            "time": dict,  # Serialized AbsoluteDateArray
+            "rotations": list,  # List of rotations:
+                                # - If "rotations_type" is "quaternion": List of quaternions (Nx4),
+                                #   where each quaternion is [x, y, z, w] (scalar-last format).
+                                # - If "rotations_type" is "euler": List of Euler angles (Nx3)
+            "rotations_type": str,  # Type of rotations: "quaternion" (default) or "euler"
+            "euler_order": str (optional),  # Order (e.g., "xyz"), if "rotations_type" is "euler"
+            "base": str,  # Base reference frame as a string identifier
+            "angular_velocity": list (optional)  # List of angular velocity vectors (Nx3)
+        }
+
+        Args:
+            data (dict): Serialized AttitudeSeries dictionary.
+
+        Returns:
+            AttitudeSeries: Reconstructed AttitudeSeries object.
+
+        Raises:
+            ValueError: If "rotations_type" is "euler" but "euler_order" is missing.
+        """
+        time = AbsoluteDateArray.from_dict(data["time"])
+        rotations_type = data.get("rotations_type", "quaternion")
+
+        if rotations_type == "quaternion":
+            rotations = Rotation.from_quat(data["rotations"])
+        elif rotations_type == "euler":
+            euler_order = data.get("euler_order")
+            if not euler_order:
+                raise ValueError(
+                    "euler_order is required when rotations_type is 'euler'."
+                )
+            rotations = Rotation.from_euler(euler_order, data["rotations"])
+        else:
+            raise ValueError(f"Unsupported rotations_type: {rotations_type}")
+
+        base = ReferenceFrame.get(
+            data["base"]
+        )  # Deserialize base as ReferenceFrame
+
+        angular_velocity = (
+            np.array(data["angular_velocity"])
+            if "angular_velocity" in data
+            else None
+        )
+        return cls(time, rotations, base, angular_velocity)
+
+    def at(
+        self, t: Union[AbsoluteDate, AbsoluteDateArray]
+    ) -> tuple[Rotation, np.ndarray]:
+        """
+        Get the interpolated rotations and angular velocity at the specified time(s).
+
+        Args:
+            new_dates (AbsoluteDate or AbsoluteDateArray): Time(s) at which to evaluate.
+
+        Returns:
+            - If AbsoluteDate: a tuple (Rotation, angular_velocity_vector).
+            - If AbsoluteDateArray: a tuple (Rotation, ndarray of angular velocities).
+        """
+        if isinstance(t, AbsoluteDate):
+            new_et = np.array([t.ephemeris_time])
+            rot, angvel = self._resample(new_et)
+            return rot[0], angvel[0]
+        elif isinstance(t, AbsoluteDateArray):
+            return self._resample(t.ephemeris_time)
+        else:
+            raise TypeError(
+                "new_dates must be an AbsoluteDate or AbsoluteDateArray."
+            )
+
+    def _resample(self, new_et: np.ndarray) -> tuple[Rotation, np.ndarray]:
+        """
+        Internal method to perform SLERP and angular velocity assignment.
+
+        Args:
+            new_et (np.ndarray): New ephemeris times (1D array).
+
+        Returns:
+            Tuple[Rotation, np.ndarray]: Interpolated rotations and angular velocity.
+        """
+        slerp = Slerp(self.time.ephemeris_time, self.rotations)
+        new_rotations = slerp(new_et)
+
+        indices = (
+            np.searchsorted(self.time.ephemeris_time, new_et, side="right") - 1
+        )
+        indices = np.clip(indices, 0, len(self.angular_velocity) - 1)
+        new_angular_velocity = self.angular_velocity[indices]
+
+        return new_rotations, new_angular_velocity
+
+    def resample(self, new_time: AbsoluteDateArray) -> "AttitudeSeries":
+        """
+        Resample AttitudeSeries to a new time base using spherical linear interpolation (SLERP).
+
+        Args:
+            new_time (AbsoluteDateArray): New time samples for interpolation.
+
+        Returns:
+            AttitudeSeries: New AttitudeSeries interpolated at the requested times.
+        """
+        new_rotations, new_angular_velocity = self._resample(
+            new_time.ephemeris_time
+        )
+        return AttitudeSeries(
+            time=new_time,
+            rotations=new_rotations,
+            base=self.base,
+            angular_velocity=new_angular_velocity,
+        )
+
+    @classmethod
+    def constant_velocity(
+        cls,
+        start_time: "AbsoluteDate",
+        duration: float,
+        initial_rotation: Rotation,
+        angular_velocity: np.ndarray,
+        base: ReferenceFrame,
+    ) -> "AttitudeSeries":
+        """
+        Create an AttitudeSeries with a constant angular velocity.
+
+        Args:
+            start_time (AbsoluteDate): The starting time of the series.
+            duration (float): Duration of the series in seconds.
+            initial_rotation (Rotation): Initial orientation as a scipy Rotation object.
+            angular_velocity (np.ndarray): Constant angular velocity vector (3D) in rad/s.
+            base (ReferenceFrame): Base reference frame.
+
+        Returns:
+            AttitudeSeries: A new AttitudeSeries object.
+        """
+        if angular_velocity.shape != (3,):
+            raise ValueError("Angular velocity must be a 3D vector.")
+
+        # Generate start and stop time samples
+        time_samples = np.array(
+            [
+                start_time.ephemeris_time,
+                start_time.ephemeris_time + duration,
+            ]
+        )
+        time_array = AbsoluteDateArray(time_samples)
+
+        # Compute rotations at start and stop times
+        delta_rotation = Rotation.from_rotvec(angular_velocity * duration)
+        rotations = Rotation.from_quat(
+            [
+                initial_rotation.as_quat(),
+                (initial_rotation * delta_rotation).as_quat(),
+            ]
+        )
+
+        # Return the new AttitudeSeries
+        return cls(
+            time=time_array,
+            rotations=rotations,
+            base=base,
+            angular_velocity=np.tile(angular_velocity, (2, 1)),
+        )
+
+    @classmethod
+    def get_lvlh(cls, state: StateSeries) -> "AttitudeSeries":
+        """
+        Compute an LVLH AttitudeSeries from a StateSeries in an inertial reference frame.
+
+        Args:
+            state (StateSeries): Trajectory in an inertial frame.
+
+        Returns:
+            AttitudeSeries: LVLH AttitudeSeries relative to state.frame.
+
+        Raises:
+            ValueError: If the state frame is not an inertial frame.
+        """
+        # Only support ICRF_EC as inertial
+        if state.frame != ReferenceFrame.ICRF_EC:
+            raise ValueError(
+                f"LVLH only defined for inertial frames, got {state.frame}"
+            )
+
+        pos = state.data[0]  # shape (N,3)
+        vel = state.data[1]  # shape (N,3)
+
+        # Build direction cosine matrices
+        r_mats = []
+        for r, v in zip(pos, vel):
+            r_norm = np.linalg.norm(r)
+            if r_norm == 0:
+                raise ValueError(
+                    "Position vector has zero norm; cannot define LVLH axes"
+                )
+            x_hat = r / r_norm
+            h = np.cross(r, v)
+            h_norm = np.linalg.norm(h)
+            if h_norm == 0:
+                raise ValueError(
+                    "Angular momentum vector has zero norm; cannot define LVLH axes"
+                )
+            z_hat = h / h_norm
+            y_hat = np.cross(z_hat, x_hat)
+            # Rows are LVLH axes in inertial coordinates
+            r_mats.append(np.vstack([x_hat, y_hat, z_hat]))
+
+        rotations = Rotation.from_matrix(np.array(r_mats))
+        return cls(time=state.time, rotations=rotations, base=state.frame)

--- a/eosimutils/base.py
+++ b/eosimutils/base.py
@@ -48,32 +48,3 @@ class EnumBase(str, Enum):
         if isinstance(other, str):
             return self.value == other.upper()
         return False
-
-
-class ReferenceFrame(EnumBase):
-    """
-    Enumeration of recognized Reference frames.
-
-    Attributes:
-
-        ICRF_EC (str): Earth centered inertial frame aligned to the ICRF
-                        (International Celestial Reference Frame) .
-
-                    The alignment of the ICRF is as defined in the SPICE toolkit.
-                    This is implemented with the J2000 frame defined in the SPICE toolkit.
-                    It seems that J2000 is same as ICRF.
-                    In SPICE the center of any inertial frame is ALWAYS the solar system barycenter.
-                    See Slide 12 and 7 in
-                    https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/Tutorials/pdf/individual_docs/17_frames_and_coordinate_systems.pdf
-
-        ITRF (str): International Terrestrial Reference Frame.
-                    This is implemented with the ITRF93 frame defined in the SPICE toolkit.
-
-                    Also see:
-                    https://rhodesmill.org/skyfield/api-framelib.html#skyfield.framelib.itrs
-
-    """
-
-    ICRF_EC = "ICRF_EC"  # Geocentric Celestial Reference Frame (ECI)
-    ITRF = "ITRF"  # International Terrestrial Reference Frame (ECEF)
-    # TEME = "TEME"  # True Equator Mean Equinox

--- a/eosimutils/base.py
+++ b/eosimutils/base.py
@@ -77,3 +77,16 @@ class ReferenceFrame(EnumBase):
     ICRF_EC = "ICRF_EC"  # Geocentric Celestial Reference Frame (ECI)
     ITRF = "ITRF"  # International Terrestrial Reference Frame (ECEF)
     # TEME = "TEME"  # True Equator Mean Equinox
+
+
+class RotationsType(EnumBase):
+    """
+    Enumeration of recognized rotation types.
+
+    Attributes:
+        QUATERNION (str): Represents quaternion rotations.
+        EULER (str): Represents Euler angle rotations.
+    """
+
+    QUATERNION = "QUATERNION"
+    EULER = "EULER"

--- a/eosimutils/base.py
+++ b/eosimutils/base.py
@@ -50,35 +50,6 @@ class EnumBase(str, Enum):
         return False
 
 
-class ReferenceFrame(EnumBase):
-    """
-    Enumeration of recognized Reference frames.
-
-    Attributes:
-
-        ICRF_EC (str): Earth centered inertial frame aligned to the ICRF
-                        (International Celestial Reference Frame) .
-
-                    The alignment of the ICRF is as defined in the SPICE toolkit.
-                    This is implemented with the J2000 frame defined in the SPICE toolkit.
-                    It seems that J2000 is same as ICRF.
-                    In SPICE the center of any inertial frame is ALWAYS the solar system barycenter.
-                    See Slide 12 and 7 in
-                    https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/Tutorials/pdf/individual_docs/17_frames_and_coordinate_systems.pdf
-
-        ITRF (str): International Terrestrial Reference Frame.
-                    This is implemented with the ITRF93 frame defined in the SPICE toolkit.
-
-                    Also see:
-                    https://rhodesmill.org/skyfield/api-framelib.html#skyfield.framelib.itrs
-
-    """
-
-    ICRF_EC = "ICRF_EC"  # Geocentric Celestial Reference Frame (ECI)
-    ITRF = "ITRF"  # International Terrestrial Reference Frame (ECEF)
-    # TEME = "TEME"  # True Equator Mean Equinox
-
-
 class RotationsType(EnumBase):
     """
     Enumeration of recognized rotation types.

--- a/eosimutils/frame_registry.py
+++ b/eosimutils/frame_registry.py
@@ -1,0 +1,177 @@
+"""
+.. module:: eosimutils.frame_registry
+   :synopsis: Reference frame registry..
+"""
+
+from scipy.spatial.transform import Rotation as R
+from collections import deque
+from typing import Dict, Union
+import numpy as np
+
+from .frames import ReferenceFrame
+from .time import AbsoluteDate, AbsoluteDateArray
+from .attitude import Attitude, SpiceAttitude
+
+
+class _InverseAttitude(Attitude):
+    """
+    Internal: wraps another Attitude and inverts its rotation and angular velocity.
+    """
+
+    def __init__(self, original: Attitude):
+        self._orig = original
+
+    def at(
+        self, t: Union[AbsoluteDate, AbsoluteDateArray]
+    ) -> tuple[R, np.ndarray]:
+        rot, w = self._orig.at(t)
+        rot_inv = rot.inv()
+        w_inv = -rot_inv.apply(w)
+        return rot_inv, w_inv
+
+
+class FrameRegistry:
+    """
+    Registry for time-varying coordinate frame transformations.
+
+    Underlying data structure:
+    - Frames and transforms form a graph: nodes are ReferenceFrames, edges are Attitudes.
+    - Adjacency list `_adj`: dict maps each frame to a dict of neighbor ReferenceFrames → Attitude.
+    - Querying A->B at time t:
+        1. BFS to discover a path through intermediate frames.
+        2. At each edge, call its Attitude.at(t) to get the rotation(s) and angular velocity(ies).
+        3. Compose the rotations and angular velocities along the path to yield the transform.
+    """
+
+    def __init__(self):
+        """
+        Initializes an adjacency list for frame transformations.
+        By default, it contains transforms for ICRF_EC and ITRF frames.
+        """
+        # Initialize empty adjacency list
+        self._adj: Dict[ReferenceFrame, Dict[ReferenceFrame, Attitude]] = {}
+
+        # Add spice transforms
+        self.add_spice_transforms()
+
+    def add_spice_transforms(self):
+        """
+        Adds SPICE transforms for ICRF_EC and ITRF frames.
+        """
+        # Add transforms from ICRF_EC to ITRF
+        self.add_transform(
+            ReferenceFrame.ICRF_EC,
+            ReferenceFrame.ITRF,
+            SpiceAttitude(ReferenceFrame.ICRF_EC, ReferenceFrame.ITRF),
+            False,
+        )
+
+        # Add transforms from ITRF to ICRF_EC
+        self.add_transform(
+            ReferenceFrame.ITRF,
+            ReferenceFrame.ICRF_EC,
+            SpiceAttitude(ReferenceFrame.ITRF, ReferenceFrame.ICRF_EC),
+            False,
+        )
+
+    def add_transform(
+        self,
+        from_frame: ReferenceFrame,
+        to_frame: ReferenceFrame,
+        attitude: Attitude,
+        set_inverse: bool = True,
+    ):
+        """
+        Registers a direct Attitude instance from `from_frame` to `to_frame`.
+        Optionally registers the inverse for the reverse direction.
+
+        Args:
+            from_frame (ReferenceFrame): Source frame.
+            to_frame (ReferenceFrame): Target frame.
+            attitude (Attitude): Attitude instance mapping from_frame→to_frame.
+            set_inverse (bool, optional): Whether to automatically register the inverse transform.
+                Default is True.
+        """
+        # Store forward attitude in adjacency list
+        if from_frame not in self._adj:
+            self._adj[from_frame] = {}
+        self._adj[from_frame][to_frame] = attitude
+
+        # Store inverse attitude if set_inverse is True
+        if set_inverse:
+            if to_frame not in self._adj:
+                self._adj[to_frame] = {}
+            self._adj[to_frame][from_frame] = _InverseAttitude(attitude)
+
+    def get_transform(
+        self,
+        from_frame: ReferenceFrame,
+        to_frame: ReferenceFrame,
+        t: Union[AbsoluteDate, AbsoluteDateArray],
+    ) -> tuple[R, np.ndarray]:
+        """
+        Computes the composed transform from `from_frame` to `to_frame` at time `t`.
+
+        Args:
+            from_frame (ReferenceFrame): Source frame.
+            to_frame (ReferenceFrame): Target frame.
+            t (Union[AbsoluteDate, AbsoluteDateArray]): AbsoluteDate or AbsoluteDateArray
+                representing the time(s).
+
+        Returns:
+            tuple[R, np.ndarray]: scipy Rotation object and angular velocity vector for transform.
+
+        Raises:
+            KeyError: If no path exists.
+        """
+        # Determine if input is single or multiple dates
+        is_single = isinstance(t, AbsoluteDate)
+
+        # Identity if same frame
+        if from_frame == to_frame:
+            return (
+                (R.identity(), np.zeros(3))
+                if is_single
+                else (
+                    R.identity(len(t.ephemeris_time)),
+                    np.zeros((len(t.ephemeris_time), 3)),
+                )
+            )
+
+        visited = {from_frame}
+        zero_w = (
+            np.zeros(3) if is_single else np.zeros((len(t.ephemeris_time), 3))
+        )
+        # Prepare initial BFS queue: (frame, accumulated_rotation, accumulated_angular_velocity)
+        queue = deque(
+            [
+                (
+                    from_frame,
+                    (
+                        R.identity()
+                        if is_single
+                        else R.identity(len(t.ephemeris_time))
+                    ),
+                    zero_w,
+                )
+            ]
+        )
+
+        # BFS loop
+        while queue:
+            curr_frame, acc_rot, acc_w = queue.popleft()
+            for nbr, att in self._adj.get(curr_frame, {}).items():
+                if nbr in visited:
+                    continue
+                rot, w = att.at(t)
+                new_rot = rot * acc_rot
+                new_w = rot.apply(acc_w) + w
+                if nbr == to_frame:
+                    return new_rot, new_w
+                visited.add(nbr)
+                queue.append((nbr, new_rot, new_w))
+
+        # No path found
+        raise KeyError(
+            f"No transform path from '{from_frame}' to '{to_frame}' at time {t}"
+        )

--- a/eosimutils/frame_registry.py
+++ b/eosimutils/frame_registry.py
@@ -18,7 +18,8 @@ class FrameRegistry:
     Registry for time-varying coordinate frame transformations.
 
     Underlying data structure:
-    - Frames/transforms form a graph: nodes are ReferenceFrames/edges are Orientation instances.
+    - Frames and transforms form a graph: nodes are ReferenceFrames and edges are Orientation
+    instances.
     - Adjacency list `_adj`: maps each source ReferenceFrame to a list of Orientation edges.
     - Querying A->B at time t:
         1. BFS to discover a path through intermediate frames.
@@ -59,7 +60,10 @@ class FrameRegistry:
         set_inverse: bool = True,
     ):
         """
-        Registers a direct Orientation instance using its from_frame and to_frame attributes.
+        Registers a transformation between two reference frames using Orientation instance.
+
+        This creates a directed edge in the graph from `from_frame` to `to_frame`, which
+        are member variables of the Orientation instance.
         Optionally registers the inverse for the reverse direction.
 
         Args:

--- a/eosimutils/frame_registry.py
+++ b/eosimutils/frame_registry.py
@@ -45,12 +45,16 @@ class FrameRegistry:
 
         # Add transforms from ICRF_EC to ITRF
         self.add_transform(
-            SpiceOrientation(ReferenceFrame.ICRF_EC, ReferenceFrame.ITRF),
+            SpiceOrientation(
+                ReferenceFrame.get("ICRF_EC"), ReferenceFrame.get("ITRF")
+            ),
             False,
         )
         # Add transforms from ITRF to ICRF_EC
         self.add_transform(
-            SpiceOrientation(ReferenceFrame.ITRF, ReferenceFrame.ICRF_EC),
+            SpiceOrientation(
+                ReferenceFrame.get("ITRF"), ReferenceFrame.get("ICRF_EC")
+            ),
             False,
         )
 

--- a/eosimutils/frames.py
+++ b/eosimutils/frames.py
@@ -93,15 +93,23 @@ class ReferenceFrame(metaclass=ReferenceFrameMeta):
     @classmethod
     def add(cls, name: str) -> "ReferenceFrame":
         """
-        Adds a new reference frame to the registry.
+        Dynamically add a new reference frame.
 
         Args:
             name (str): Name of the new reference frame.
+
         Returns:
-            ReferenceFrame: The newly created reference frame instance.
+            ReferenceFrame: The newly added reference frame.
         """
-        name = name.upper()
-        return cls._frames.get(name) or cls(name)
+        name_upper = name.upper()
+        if name_upper in cls._frames:
+            raise ValueError(f"Frame '{name}' already exists.")
+        instance = cls(name_upper)
+        cls._frames[name_upper] = instance
+        setattr(
+            cls, name_upper, instance
+        )  # Dynamically create a class-level attribute
+        return instance
 
     @classmethod
     def values(cls) -> List["ReferenceFrame"]:
@@ -114,5 +122,5 @@ class ReferenceFrame(metaclass=ReferenceFrameMeta):
 
 # Add enum-like static members
 for _name in ["ICRF_EC", "ITRF"]:
-    instance = ReferenceFrame(_name)
-    setattr(ReferenceFrame, _name, instance)
+    inst = ReferenceFrame(_name)
+    setattr(ReferenceFrame, _name, inst)

--- a/eosimutils/frames.py
+++ b/eosimutils/frames.py
@@ -1,0 +1,203 @@
+"""
+.. module:: eosimutils.frames
+   :synopsis: Reference frame representation..
+"""
+
+from .base import EnumBase
+from scipy.spatial.transform import Rotation as R  # Import Rotation from scipy
+from collections import deque
+from typing import Callable, Dict, Union
+import numpy as np
+
+from eosimutils.time import AbsoluteDate, AbsoluteDateArray
+
+
+class ReferenceFrame(EnumBase):
+    """
+    Enumeration of recognized Reference frames.
+
+    Attributes:
+
+        ICRF_EC (str): Earth centered inertial frame aligned to the ICRF
+                        (International Celestial Reference Frame) .
+
+                    The alignment of the ICRF is as defined in the SPICE toolkit.
+                    This is implemented with the J2000 frame defined in the SPICE toolkit.
+                    It seems that J2000 is same as ICRF.
+                    In SPICE the center of any inertial frame is ALWAYS the solar system barycenter.
+                    See Slide 12 and 7 in
+                    https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/Tutorials/pdf/individual_docs/17_frames_and_coordinate_systems.pdf
+
+        ITRF (str): International Terrestrial Reference Frame.
+                    This is implemented with the ITRF93 frame defined in the SPICE toolkit.
+
+                    Also see:
+                    https://rhodesmill.org/skyfield/api-framelib.html#skyfield.framelib.itrs
+
+    """
+
+    ICRF_EC = "ICRF_EC"  # Geocentric Celestial Reference Frame (ECI)
+    ITRF = "ITRF"  # International Terrestrial Reference Frame (ECEF)
+    # TEME = "TEME"  # True Equator Mean Equinox
+
+
+# A TransformFunc maps a single AbsoluteDate to a scipy Rotation object
+TransformFunc = Callable[[AbsoluteDate], R]
+
+# A TransformsFunc maps an AbsoluteDateArray to a scipy Rotation object containing multiple rotations
+TransformsFunc = Callable[[AbsoluteDateArray], R]
+
+
+class FrameRegistry:
+    """
+    Registry for time-varying coordinate frame transformations.
+
+    Underlying data structure:
+    - Frames and transforms form a graph: nodes are frame names, edges are transform functions.
+    - Adjacency list `_adj`: dict mapping each frame to a dict of neighbor-frame names → TransformFunc/TransformsFunc.
+    - Querying A->B at time t:
+    1. BFS to discover a path through intermediate frames.
+    2. At each edge, call its TransformFunc(t) or TransformsFunc(ts) to get the rotation(s).
+    3. Compose the rotations along the path to yield the composite rotation(s).
+
+    Attributes:
+        _adj (Dict[str, Dict[str, Dict[str, Union[TransformFunc, TransformsFunc]]]]):
+            Adjacency list representing the frame graph.
+            _adj[frame_i][frame_j] = {"single": f_{i->j}(t), "multiple": f_{i->j}(ts)}.
+    """
+
+    def __init__(self):
+        """
+        Initializes an empty adjacency list for the frame graph.
+        """
+        # Initialize empty adjacency list
+        self._adj: Dict[
+            str, Dict[str, Dict[str, Union[TransformFunc, TransformsFunc]]]
+        ] = {}
+
+    def add_transform(
+        self,
+        from_frame: str,
+        to_frame: str,
+        transform_func: TransformFunc,
+        transforms_func: TransformsFunc = None,
+        set_inverse: bool = True,
+    ):
+        """
+        Registers a direct transform function from `from_frame` to `to_frame`.
+        Optionally registers the inverse for the reverse direction.
+
+        Args:
+            from_frame (str): Name of the source frame.
+            to_frame (str): Name of the target frame.
+            transform_func (TransformFunc): Function f(t: AbsoluteDate) -> scipy Rotation object
+                mapping from_frame→to_frame.
+            transforms_func (TransformsFunc, optional): Function f(ts: AbsoluteDateArray) -> scipy
+                Rotation object containing multiple rotations. Defaults to applying `transform_func`
+                to each date in the array.
+            set_inverse (bool, optional): Whether to automatically register the inverse transform.
+                Default is True.
+        """
+
+        # Default transforms_func if not provided
+        if transforms_func is None:
+
+            def transforms_func(ts: AbsoluteDateArray):
+                return R.from_quat(
+                    [transform_func(t).as_quat() for t in ts.ephemeris_time]
+                )
+
+        # Build inverse functions for single and multiple dates
+        def inv_func(t: AbsoluteDate, func=transform_func):
+            return func(t).inv()
+
+        def inv_transforms_func(ts: AbsoluteDateArray, func=transforms_func):
+            return func(ts).inv()
+
+        # Store forward transform in adjacency list
+        if from_frame not in self._adj:
+            self._adj[from_frame] = {}
+        self._adj[from_frame][to_frame] = {
+            "single": transform_func,
+            "multiple": transforms_func,
+        }
+
+        # Store inverse transform if set_inverse is True
+        if set_inverse:
+            if to_frame not in self._adj:
+                self._adj[to_frame] = {}
+            self._adj[to_frame][from_frame] = {
+                "single": inv_func,
+                "multiple": inv_transforms_func,
+            }
+
+    def get_transform(
+        self,
+        from_frame: str,
+        to_frame: str,
+        t: Union[AbsoluteDate, AbsoluteDateArray],
+    ) -> R:
+        """
+        Computes the composed transform from `from_frame` to `to_frame` at time `t`.
+
+        Args:
+            from_frame (str): Name of the source frame.
+            to_frame (str): Name of the target frame.
+            t (Union[AbsoluteDate, AbsoluteDateArray]): AbsoluteDate or AbsoluteDateArray
+                representing the time(s).
+
+        Returns:
+            R: scipy Rotation object representing the composite transform(s).
+
+        Raises:
+            KeyError: If no path exists.
+        """
+        # Determine if input is single or multiple dates
+        is_single = isinstance(t, AbsoluteDate)
+
+        # Identity if same frame
+        if from_frame == to_frame:
+            return (
+                R.identity() if is_single else R.identity(len(t.ephemeris_time))
+            )
+
+        visited = {from_frame}
+        # Prepare initial BFS queue: (frame, accumulated_rotation)
+        first_nbrs = self._adj.get(from_frame, {})
+        queue = deque(
+            [
+                (
+                    from_frame,
+                    (
+                        R.identity()
+                        if is_single
+                        else R.identity(len(t.ephemeris_time))
+                    ),
+                )
+            ]
+        )
+
+        # BFS loop
+        while queue:
+            curr_frame, acc = queue.popleft()
+            for nbr, funcs in self._adj.get(curr_frame, {}).items():
+                if nbr in visited:
+                    continue
+                func = funcs["single"] if is_single else funcs["multiple"]
+                rot = func(t)
+                new_acc = rot * acc
+                if nbr == to_frame:
+                    return new_acc
+                visited.add(nbr)
+                queue.append((nbr, new_acc))
+
+        # No path found
+        raise KeyError(
+            f"No transform path from '{from_frame}' to '{to_frame}' at time {t}"
+        )
+
+
+# Module-level singleton
+registry = FrameRegistry()
+
+# Add spice transforms

--- a/eosimutils/frames.py
+++ b/eosimutils/frames.py
@@ -97,9 +97,7 @@ class ReferenceFrame:
 
 
 # Pre-register static frames
-ReferenceFrame._registry["ICRF_EC"] = ReferenceFrame(
-    "ICRF_EC"
-)  # pylint: disable=protected-access
-ReferenceFrame._registry["ITRF"] = ReferenceFrame(
-    "ITRF"
-)  # pylint: disable=protected-access
+# pylint: disable=protected-access
+ReferenceFrame._registry["ICRF_EC"] = ReferenceFrame("ICRF_EC")
+# pylint: disable=protected-access
+ReferenceFrame._registry["ITRF"] = ReferenceFrame("ITRF")

--- a/eosimutils/frames.py
+++ b/eosimutils/frames.py
@@ -3,40 +3,14 @@
    :synopsis: Reference frame representation..
 """
 
-from typing import Dict, Union, List, Optional
 
+class ReferenceFrame:
+    """Reference frame registry with static and dynamic support."""
 
-class ReferenceFrameMeta(type):
-    """
-    Metaclass for ReferenceFrame to allow iteration over class (enum-like behavior).
-    """
-
-    def __iter__(cls):
-        return iter(cls._frames.values())
-
-
-class ReferenceFrame(metaclass=ReferenceFrameMeta):
-    """
-    Enum-like class with support for dynamically added reference frames.
-
-    Behaves like an Enum:
-    - Allows class-level access to static members (e.g. ReferenceFrame.ICRF_EC)
-    - Supports ReferenceFrame.get("ICRF_EC")
-    - Supports iteration: for frame in ReferenceFrame
-    - Supports dynamic addition: ReferenceFrame.add("NEW_FRAME")
-    """
-
-    _frames: Dict[str, "ReferenceFrame"] = {}
+    _registry = {}
 
     def __init__(self, name: str):
-        """
-        Initializes a reference frame with a given name.
-
-        Args:
-            name (str): Name of the reference frame.
-        """
         self._name = name.upper()
-        ReferenceFrame._frames[self._name] = self
 
     def __str__(self):
         return self._name
@@ -44,83 +18,88 @@ class ReferenceFrame(metaclass=ReferenceFrameMeta):
     def __repr__(self):
         return f"ReferenceFrame('{self._name}')"
 
-    def to_string(self) -> str:
-        return self._name
-
-    def __eq__(self, other: Union[str, "ReferenceFrame"]) -> bool:
+    def to_string(self):
         """
-        Compares this reference frame with another.
-
-        Args:
-            other (Union[str, ReferenceFrame]): Other reference frame or string to compare with.
+        Converts the reference frame to a string.
 
         Returns:
-                bool: True if they are equal, False otherwise.
+            str: The name of the reference frame.
         """
+        return self._name
+
+    def __eq__(self, other):
         if isinstance(other, ReferenceFrame):
             return self._name == other._name
         if isinstance(other, str):
             return self._name == other.upper()
+
         return False
 
     def __hash__(self):
         return hash(self._name)
 
     @classmethod
-    def get(
-        cls,
-        key: Union[str, "ReferenceFrame", List[Union[str, "ReferenceFrame"]]],
-    ) -> Optional[Union["ReferenceFrame", List["ReferenceFrame"]]]:
+    def add(cls, name: str):
         """
-        Retrieves a reference frame by name or instance.
+        Dynamically adds a new ReferenceFrame.
 
         Args:
-            key (Union[str, ReferenceFrame, List[Union[str, ReferenceFrame]]]): The name or
-                instance of the reference frame.
-
-        Returns:
-            Optional[Union[ReferenceFrame, List[ReferenceFrame]]]: The reference frame instance
-                or a list of instances.
-        """
-        if isinstance(key, list):
-            return [cls.get(k) for k in key]
-        if isinstance(key, ReferenceFrame):
-            return key
-        if isinstance(key, str):
-            return cls._frames.get(key.upper())
-        return None
-
-    @classmethod
-    def add(cls, name: str) -> "ReferenceFrame":
-        """
-        Dynamically add a new reference frame.
-
-        Args:
-            name (str): Name of the new reference frame.
+            name (str): The name of the reference frame to add.
 
         Returns:
             ReferenceFrame: The newly added reference frame.
+
+        Raises:
+            ValueError: If the reference frame already exists.
         """
-        name_upper = name.upper()
-        if name_upper in cls._frames:
+        name = name.upper()
+        if name in cls._registry:
             raise ValueError(f"Frame '{name}' already exists.")
-        instance = cls(name_upper)
-        cls._frames[name_upper] = instance
-        setattr(
-            cls, name_upper, instance
-        )  # Dynamically create a class-level attribute
-        return instance
+        cls._registry[name] = ReferenceFrame(name)
+        return cls._registry[name]
 
     @classmethod
-    def values(cls) -> List["ReferenceFrame"]:
-        return list(cls._frames.values())
+    def get(cls, name: str):
+        """
+        Retrieves a ReferenceFrame by name.
+
+        Args:
+            name (str): The name of the reference frame to retrieve.
+
+        Returns:
+            Optional[ReferenceFrame]: The reference frame if found, None otherwise.
+        """
+        name = name.upper()
+        if name not in cls._registry:
+            return None
+
+        return cls._registry[name]
 
     @classmethod
-    def names(cls) -> List[str]:
-        return list(cls._frames.keys())
+    def values(cls):
+        """
+        Retrieves all registered reference frames.
+
+        Returns:
+            List[ReferenceFrame]: A list of all registered reference frames.
+        """
+        return list(cls._registry.values())
+
+    @classmethod
+    def names(cls):
+        """
+        Retrieves the names of all registered reference frames.
+
+        Returns:
+            List[str]: A list of all registered reference frame names.
+        """
+        return list(cls._registry.keys())
 
 
-# Add enum-like static members
-for _name in ["ICRF_EC", "ITRF"]:
-    inst = ReferenceFrame(_name)
-    setattr(ReferenceFrame, _name, inst)
+# Pre-register static frames
+ReferenceFrame._registry["ICRF_EC"] = ReferenceFrame(
+    "ICRF_EC"
+)  # pylint: disable=protected-access
+ReferenceFrame._registry["ITRF"] = ReferenceFrame(
+    "ITRF"
+)  # pylint: disable=protected-access

--- a/eosimutils/frames.py
+++ b/eosimutils/frames.py
@@ -5,7 +5,11 @@
 
 
 class ReferenceFrame:
-    """Reference frame registry with static and dynamic support."""
+    """Reference frame registry with static and dynamic support.
+
+    Reference frames are stored in a (class-variable) dictionary providing lookup by name.
+    Hence, there is only one ReferenceFrame registry shared globally across the application.
+    """
 
     _registry = {}
 
@@ -61,14 +65,16 @@ class ReferenceFrame:
     @classmethod
     def get(cls, name: str):
         """
-        Retrieves a ReferenceFrame by name.
+        Retrieves a ReferenceFrame by name or returns the instance if already a ReferenceFrame.
 
         Args:
-            name (str): The name of the reference frame to retrieve.
+            name (str or ReferenceFrame): The name of the reference frame to retrieve, or a ReferenceFrame instance.
 
         Returns:
-            Optional[ReferenceFrame]: The reference frame if found, None otherwise.
+            ReferenceFrame or None: The reference frame if found, the instance if already a ReferenceFrame, or None if not found.
         """
+        if isinstance(name, ReferenceFrame):
+            return name
         name = name.upper()
         if name not in cls._registry:
             return None

--- a/eosimutils/kinematic.py
+++ b/eosimutils/kinematic.py
@@ -14,7 +14,7 @@ from typing import Optional, Union
 
 import spiceypy as spice
 
-from .base import ReferenceFrame
+from .frames import ReferenceFrame
 from .time import AbsoluteDate
 from .state import Cartesian3DPosition, CartesianState
 

--- a/eosimutils/kinematic.py
+++ b/eosimutils/kinematic.py
@@ -41,7 +41,7 @@ def _transform_position_vector(
         # No transformation needed, return the same position
         return position_vector
 
-    if from_frame == ReferenceFrame.ICRF_EC and to_frame == ReferenceFrame.ITRF:
+    if from_frame == "ICRF_EC" and to_frame == "ITRF":
         # Transform from ICRF_EC to ITRF
         if et is not None:
             rot_matrix = spice.pxform("J2000", "ITRF93", et)
@@ -49,9 +49,7 @@ def _transform_position_vector(
             raise ValueError(
                 "Ephemeris time (ET) must be provided for transformation."
             )
-    elif (
-        from_frame == ReferenceFrame.ITRF and to_frame == ReferenceFrame.ICRF_EC
-    ):
+    elif from_frame == "ITRF" and to_frame == "ICRF_EC":
         # Transform from ITRF to ICRF_EC
         if et is not None:
             rot_matrix = spice.pxform("ITRF93", "J2000", et)
@@ -114,11 +112,9 @@ def _transform_state(
         # No transformation needed, return the same state
         return state
 
-    if from_frame == ReferenceFrame.ICRF_EC and to_frame == ReferenceFrame.ITRF:
+    if from_frame == "ICRF_EC" and to_frame == "ITRF":
         state_matrix = spice.sxform("J2000", "ITRF93", et)
-    elif (
-        from_frame == ReferenceFrame.ITRF and to_frame == ReferenceFrame.ICRF_EC
-    ):
+    elif from_frame == "ITRF" and to_frame == "ICRF_EC":
         state_matrix = spice.sxform("ITRF93", "J2000", et)
     else:
         raise NotImplementedError(

--- a/eosimutils/kinematic.py
+++ b/eosimutils/kinematic.py
@@ -41,7 +41,9 @@ def _transform_position_vector(
         # No transformation needed, return the same position
         return position_vector
 
-    if from_frame == "ICRF_EC" and to_frame == "ITRF":
+    if from_frame == ReferenceFrame.get(
+        "ICRF_EC"
+    ) and to_frame == ReferenceFrame.get("ITRF"):
         # Transform from ICRF_EC to ITRF
         if et is not None:
             rot_matrix = spice.pxform("J2000", "ITRF93", et)
@@ -49,7 +51,9 @@ def _transform_position_vector(
             raise ValueError(
                 "Ephemeris time (ET) must be provided for transformation."
             )
-    elif from_frame == "ITRF" and to_frame == "ICRF_EC":
+    elif from_frame == ReferenceFrame.get(
+        "ITRF"
+    ) and to_frame == ReferenceFrame.get("ICRF_EC"):
         # Transform from ITRF to ICRF_EC
         if et is not None:
             rot_matrix = spice.pxform("ITRF93", "J2000", et)
@@ -112,9 +116,13 @@ def _transform_state(
         # No transformation needed, return the same state
         return state
 
-    if from_frame == "ICRF_EC" and to_frame == "ITRF":
+    if from_frame == ReferenceFrame.get(
+        "ICRF_EC"
+    ) and to_frame == ReferenceFrame.get("ITRF"):
         state_matrix = spice.sxform("J2000", "ITRF93", et)
-    elif from_frame == "ITRF" and to_frame == "ICRF_EC":
+    elif from_frame == ReferenceFrame.get(
+        "ITRF"
+    ) and to_frame == ReferenceFrame.get("ICRF_EC"):
         state_matrix = spice.sxform("ITRF93", "J2000", et)
     else:
         raise NotImplementedError(

--- a/eosimutils/orientation.py
+++ b/eosimutils/orientation.py
@@ -725,7 +725,9 @@ class OrientationSeries(Orientation):
         )
 
     @classmethod
-    def get_lvlh(cls, state: StateSeries) -> "OrientationSeries":
+    def get_lvlh(
+        cls, state: StateSeries, lvlh_frame: ReferenceFrame
+    ) -> "OrientationSeries":
         """
         Compute an LVLH OrientationSeries from a StateSeries in an inertial reference frame.
 
@@ -739,6 +741,7 @@ class OrientationSeries(Orientation):
 
         Args:
             state (StateSeries): Trajectory in an inertial frame.
+            frame (ReferenceFrame): The ReferenceFrame object for newly created LVLH frame.
 
         Returns:
             OrientationSeries: LVLH OrientationSeries relative to state.frame.
@@ -749,7 +752,7 @@ class OrientationSeries(Orientation):
         # Only support ICRF_EC as inertial
         if state.frame != ReferenceFrame.get("ICRF_EC"):
             raise ValueError(
-                f"LVLH only defined for inertial frames, got {state.frame}"
+                f"get_LVLH only defined for inertial frames, got {state.frame}"
             )
 
         pos = state.data[0]  # shape (N,3)
@@ -767,16 +770,13 @@ class OrientationSeries(Orientation):
             y_hat = -h / h_norm  # Cross-track:-h/|h|
             x_hat = np.cross(y_hat, z_hat)  # Local horizontal: y × z
             r_mats.append(np.column_stack([x_hat, y_hat, z_hat]))
-            # r_mats.append(np.vstack([x_hat, y_hat, z_hat]))
 
         rotations = Scipy_Rotation.from_matrix(np.array(r_mats))
         return cls(
             time=state.time,
             rotations=rotations,
-            from_frame=ReferenceFrame.get("LVLH"),
+            from_frame=lvlh_frame,
             to_frame=state.frame,
-            # from_frame=state.frame,
-            # to_frame=ReferenceFrame.LVLH
         )
 
     def inverse(self) -> "OrientationSeries":

--- a/eosimutils/orientation.py
+++ b/eosimutils/orientation.py
@@ -13,18 +13,27 @@ from scipy.spatial.transform import Slerp as Scipy_Slerp
 from .frames import ReferenceFrame
 from .time import AbsoluteDate, AbsoluteDateArray
 from .trajectory import StateSeries
+from .base import RotationsType
 
 
 class Orientation:
     """
     Base class for orientation representations.
 
+    Rotations are represented using SciPy rotation objects. A rotation object, when applied to a
+    position or state (position and velocity) in from_frame, transforms the position (state) to
+    to_frame. Rotation matrices are constructed from euler angles using the counterclockwise
+    rotation convention (i.e., R(theta) is the matrix that rotates a vector counterclockwise by
+    theta, see https://mathworld.wolfram.com/RotationMatrix.html. For instance, to construct an
+    orientation object with from_frame A and to_frame B using Euler angles, the euler angles
+    which rotate the B frame to the A frame would be provided.
+
     Subclasses must implement `at(t)` to return (Scipy_Rotation, angular_velocity). Note that
     Scipy Rotation objects use the scalar-last convention for quaternions. Counterclockwise
     rotations are positive.
 
     Implements a factory pattern to create instances from a dictionary using `from_dict(data)`.
-    The dictionary must contain a "type" key to identify the subclass.
+    The dictionary must contain a "orientation_type" key to identify the subclass.
 
     Provides `transform(state, t)` to apply rotation and angular velocity to 6D state vectors.
     """
@@ -56,7 +65,7 @@ class Orientation:
         Factory method to construct an Orientation from a serialized dictionary.
         Dispatches based on registered types.
         """
-        orientation_type = data.get("type")
+        orientation_type = data.get("orientation_type")
         subclass = cls._registry.get(orientation_type)
         if not subclass:
             raise ValueError(f"Unknown orientation type: {orientation_type}")
@@ -68,7 +77,8 @@ class Orientation:
         """
         Return (rotation, angular_velocity) at the given time(s).
 
-        The angular velocity is the angular velocity of from_frame w.r.t. to_frame.
+        The angular velocity is the angular velocity of from_frame w.r.t. to_frame,
+        expressed in to_frame coordinates.
 
         Time can also be None for case of constant orientation.
 
@@ -167,12 +177,15 @@ class ConstantOrientation(Orientation):
         else:
             raise TypeError("t must be AbsoluteDate or AbsoluteDateArray")
 
-    def to_dict(self, rotations_type: str = "euler") -> Dict[str, Any]:
+    def to_dict(
+        self, rotations_type: Union[RotationsType, str] = RotationsType.EULER
+    ) -> Dict[str, Any]:
         """
         Serialize the ConstantOrientation to a dictionary.
 
         The dictionary format is as follows:
         {
+            "orientation_type": "constant",
             "rotations": list,
                 # - If "rotations_type" is "quaternion": List of 4 values [x, y, z, w]
                 # - If "rotations_type" is "euler": List of 3 values (Euler angles)
@@ -184,26 +197,30 @@ class ConstantOrientation(Orientation):
         }
 
         Args:
-            rotations_type (str): Either "quaternion" or "euler" (default: "euler").
+            rotations_type (Union[RotationsType, str]): Either RotationsType.QUATERNION or
+                RotationsType.EULER (default: RotationsType.EULER).
 
         Returns:
             dict: Serialized ConstantOrientation.
         """
-        if rotations_type == "quaternion":
+        if isinstance(rotations_type, str):
+            rotations_type = RotationsType.get(rotations_type)
+
+        if rotations_type == RotationsType.QUATERNION:
             rotations = self.rotation.as_quat()
-        elif rotations_type == "euler":
+        elif rotations_type == RotationsType.EULER:
             rotations = self.rotation.as_euler("xyz").tolist()
         else:
             raise ValueError(f"Unsupported rotations_type: {rotations_type}")
 
         result = {
-            "type": "constant",
+            "orientation_type": "constant",
             "rotations": rotations,
-            "rotations_type": rotations_type,
+            "rotations_type": rotations_type.to_string(),
             "from": self.from_frame.to_string(),
             "to": self.to_frame.to_string(),
         }
-        if rotations_type == "euler":
+        if rotations_type == RotationsType.EULER:
             result["euler_order"] = "xyz"
         return result
 
@@ -233,11 +250,13 @@ class ConstantOrientation(Orientation):
         Raises:
             ValueError: If Euler angles are used but no order is specified.
         """
-        rotations_type = data.get("rotations_type", "quaternion")
+        rotations_type = RotationsType.get(
+            data.get("rotations_type", "quaternion")
+        )
 
-        if rotations_type == "quaternion":
+        if rotations_type == RotationsType.QUATERNION:
             rotation = Scipy_Rotation.from_quat(data["rotations"])
-        elif rotations_type == "euler":
+        elif rotations_type == RotationsType.EULER:
             order = data.get("euler_order")
             if not order:
                 raise ValueError(
@@ -268,9 +287,14 @@ class SpiceOrientation(Orientation):
     """
     Orientation defined using SPICE frame transformations, including angular velocity.
 
+    If there is no mapping from from_frame or to_frame to a spice frame name in
+    the spice_names dictionary, the frame string is used directly. Hence, if
+    the frame string is a valid spice frame name this function will work.
+
     Attributes:
         from_frame (ReferenceFrame): Source frame for the SPICE transform.
         to_frame (ReferenceFrame): Target frame for the SPICE transform.
+        spice_names (dict): Mapping of ReferenceFrame to SPICE string names.
     """
 
     # Map ReferenceFrame to SPICE string names
@@ -291,8 +315,16 @@ class SpiceOrientation(Orientation):
         Returns:
             Tuple[Scipy_Rotation, np.ndarray]: Scipy_Rotation(s) and angular velocity vector(s).
         """
-        spice_from = self.spice_names[self.from_frame]
-        spice_to = self.spice_names[self.to_frame]
+
+        # If from_frame or to_frame is not in the spice_names, use the frame string directly
+        # Spiceypy will throw an error if the frame string is not recognized as a
+        # valid SPICE frame name.
+        spice_from = self.spice_names.get(
+            self.from_frame, self.from_frame.to_string()
+        )
+        spice_to = self.spice_names.get(
+            self.to_frame, self.to_frame.to_string()
+        )
 
         if isinstance(t, AbsoluteDate):
             sxform = spice.sxform(
@@ -320,10 +352,11 @@ class SpiceOrientation(Orientation):
         Serialize to a dictionary.
 
         Returns:
-            dict: Dictionary with keys "from" and "to" (ReferenceFrame string names) and "type".
+            dict: Dictionary with keys "from" and "to" (ReferenceFrame string names) and
+            "orientation_type" : spice.
         """
         return {
-            "type": "spice",
+            "orientation_type": "spice",
             "from": self.from_frame.to_string(),
             "to": self.to_frame.to_string(),
         }
@@ -363,7 +396,7 @@ class OrientationSeries(Orientation):
         rotations (Scipy_Rotation): Orientation at each time sample.
         from_frame (ReferenceFrame): Source frame for the rotations.
         to_frame (ReferenceFrame): Target frame for the rotations.
-        angular_velocity (np.ndarray): Angular velocity vectors (Nx3).
+        angular_velocity (np.ndarray): Angular velocity vectors (Nx3) of from_frame wrt to_frame.
     """
 
     def __init__(
@@ -382,8 +415,9 @@ class OrientationSeries(Orientation):
             rotations (Scipy_Rotation): Scipy_Rotation object containing N orientations.
             from_frame (ReferenceFrame): Source frame for the rotations.
             to_frame (ReferenceFrame): Target frame for the rotations.
-            angular_velocity (np.ndarray, optional): Angular velocity vectors (Nx3).
-                If None, computed automatically from rotations using finite difference.
+            angular_velocity (np.ndarray, optional): Angular velocity vectors (Nx3) of from_frame
+                wrt to_frame. If None, computed automatically from rotations using finite
+                difference.
 
         Raises:
             ValueError: If rotations length does not match time array length.
@@ -426,8 +460,8 @@ class OrientationSeries(Orientation):
             ω(t_{N−1}) ≈ v_{N−1} / (t_{N−1} − t_{N−2}).
 
         Returns:
-            np.ndarray: An (N×3) array of angular velocity vectors ω(t_i), expressed
-                        in the body-fixed frame at each sample.
+            np.ndarray: An (N×3) array of angular velocity vectors ω(t_i)
+                of from_frame wrt to_frame, expressed in to_frame coordinates.
         """
 
         rotations = self.rotations
@@ -455,13 +489,16 @@ class OrientationSeries(Orientation):
         return omega
 
     def to_dict(
-        self, rotations_type: str = "euler", euler_order: str = "xyz"
+        self,
+        rotations_type: Union[RotationsType, str] = RotationsType.EULER,
+        euler_order: str = "xyz",
     ) -> Dict[str, Any]:
         """
         Serialize this OrientationSeries into a dictionary.
 
         The dictionary format is as follows:
         {
+            "orientation_type": "series",
             "time": dict,  # Serialized AbsoluteDateArray
             "rotations": list,  # List of rotations:
                                 # - If "rotations_type" is "quaternion": List of quaternions (Nx4),
@@ -476,30 +513,34 @@ class OrientationSeries(Orientation):
         }
 
         Args:
-            rotations_type (str, optional): The type of rotations to serialize.
-                Options are "quaternion" or "euler". Defaults to "euler".
+            rotations_type (Union[RotationsType, str], optional): The type of rotations to
+                serialize. Options are RotationsType.QUATERNION or RotationsType.EULER. Defaults
+                to RotationsType.EULER.
 
         Returns:
             dict: Serialized representation of the OrientationSeries.
         """
-        if rotations_type == "quaternion":
+        if isinstance(rotations_type, str):
+            rotations_type = RotationsType.get(rotations_type)
+
+        if rotations_type == RotationsType.QUATERNION:
             rotations = self.rotations.as_quat().tolist()
-        elif rotations_type == "euler":
+        elif rotations_type == RotationsType.EULER:
             rotations = self.rotations.as_euler(euler_order).tolist()
         else:
             raise ValueError(f"Unsupported rotations_type: {rotations_type}")
 
         result = {
-            "type": "series",
+            "orientation_type": "series",
             "time": self.time.to_dict(),
             "rotations": rotations,
-            "rotations_type": rotations_type,
+            "rotations_type": rotations_type.to_string(),
             "from": self.from_frame.to_string(),
             "to": self.to_frame.to_string(),
             "angular_velocity": self.angular_velocity.tolist(),
         }
 
-        if rotations_type == "euler":
+        if rotations_type == RotationsType.EULER:
             result["euler_order"] = euler_order
 
         return result
@@ -522,7 +563,8 @@ class OrientationSeries(Orientation):
             If coordinate axes are lowercase, uses intrinsic rotations, otherwise extrinsic.
             "from": str,  # Source reference frame as a string identifier
             "to": str,  # Target reference frame as a string identifier
-            "angular_velocity": list (optional)  # List of angular velocity vectors (Nx3)
+            "angular_velocity": list (optional)  # List of angular velocity vectors (Nx3) of
+                from_frame wrt to_frame
         }
 
         Args:
@@ -535,11 +577,13 @@ class OrientationSeries(Orientation):
             ValueError: If "rotations_type" is "euler" but "euler_order" is missing.
         """
         time = AbsoluteDateArray.from_dict(data["time"])
-        rotations_type = data.get("rotations_type", "quaternion")
+        rotations_type = RotationsType.get(
+            data.get("rotations_type", "quaternion")
+        )
 
-        if rotations_type == "quaternion":
+        if rotations_type == RotationsType.QUATERNION:
             rotations = Scipy_Rotation.from_quat(data["rotations"])
-        elif rotations_type == "euler":
+        elif rotations_type == RotationsType.EULER:
             euler_order = data.get("euler_order")
             if not euler_order:
                 raise ValueError(
@@ -712,6 +756,9 @@ class OrientationSeries(Orientation):
         vel = state.data[1]  # shape (N,3)
 
         r_mats = []
+        # Form the matrix where each column is a basis vector
+        # of the LVLH frame, expressed in inertial coordinates.
+        # This is the matrix which transforms vectors from the LVLH to the inertial frame.
         for r, v in zip(pos, vel):
             r_norm = np.linalg.norm(r)
             z_hat = -r / r_norm  # Local vertical: -r/|r|
@@ -719,15 +766,17 @@ class OrientationSeries(Orientation):
             h_norm = np.linalg.norm(h)
             y_hat = -h / h_norm  # Cross-track:-h/|h|
             x_hat = np.cross(y_hat, z_hat)  # Local horizontal: y × z
-            # Rows are LVLH axes in inertial coordinates
-            r_mats.append(np.vstack([x_hat, y_hat, z_hat]))
+            r_mats.append(np.column_stack([x_hat, y_hat, z_hat]))
+            # r_mats.append(np.vstack([x_hat, y_hat, z_hat]))
 
         rotations = Scipy_Rotation.from_matrix(np.array(r_mats))
         return cls(
             time=state.time,
             rotations=rotations,
-            from_frame=state.frame,
-            to_frame=ReferenceFrame.LVLH,
+            from_frame=ReferenceFrame.LVLH,
+            to_frame=state.frame,
+            # from_frame=state.frame,
+            # to_frame=ReferenceFrame.LVLH
         )
 
     def inverse(self) -> "OrientationSeries":

--- a/eosimutils/orientation.py
+++ b/eosimutils/orientation.py
@@ -299,8 +299,8 @@ class SpiceOrientation(Orientation):
 
     # Map ReferenceFrame to SPICE string names
     spice_names = {
-        ReferenceFrame.ICRF_EC: "J2000",
-        ReferenceFrame.ITRF: "ITRF93",
+        ReferenceFrame.get("ICRF_EC"): "J2000",
+        ReferenceFrame.get("ITRF"): "ITRF93",
     }
 
     def at(
@@ -747,7 +747,7 @@ class OrientationSeries(Orientation):
             ValueError: If the state frame is not an inertial frame.
         """
         # Only support ICRF_EC as inertial
-        if state.frame != ReferenceFrame.ICRF_EC:
+        if state.frame != ReferenceFrame.get("ICRF_EC"):
             raise ValueError(
                 f"LVLH only defined for inertial frames, got {state.frame}"
             )
@@ -773,7 +773,7 @@ class OrientationSeries(Orientation):
         return cls(
             time=state.time,
             rotations=rotations,
-            from_frame=ReferenceFrame.LVLH,
+            from_frame=ReferenceFrame.get("LVLH"),
             to_frame=state.frame,
             # from_frame=state.frame,
             # to_frame=ReferenceFrame.LVLH

--- a/eosimutils/state.py
+++ b/eosimutils/state.py
@@ -113,7 +113,7 @@ class Cartesian3DPosition:
             "x": self.coords[0],
             "y": self.coords[1],
             "z": self.coords[2],
-            "frame": self.frame.value if self.frame else None,
+            "frame": self.frame.to_string() if self.frame else None,
         }
 
 
@@ -214,7 +214,7 @@ class Cartesian3DVelocity:
             "vx": self.coords[0],
             "vy": self.coords[1],
             "vz": self.coords[2],
-            "frame": self.frame.value if self.frame else None,
+            "frame": self.frame.to_string() if self.frame else None,
         }
 
 
@@ -410,7 +410,7 @@ class CartesianState:
             "time": self.time.to_dict(),
             "position": self.position.to_list(),
             "velocity": self.velocity.to_list(),
-            "frame": self.frame.value,
+            "frame": self.frame.to_string(),
         }
 
     def to_numpy(self) -> np.ndarray:

--- a/eosimutils/state.py
+++ b/eosimutils/state.py
@@ -12,7 +12,7 @@ from skyfield.positionlib import build_position as skyfield_build_position
 from skyfield.constants import AU_KM as Skyfield_AU_KM
 from skyfield.api import wgs84 as skyfield_wgs84
 
-from .base import ReferenceFrame
+from .frames import ReferenceFrame
 from .time import AbsoluteDate
 
 

--- a/eosimutils/state.py
+++ b/eosimutils/state.py
@@ -437,7 +437,7 @@ class CartesianState:
         Raises:
             ValueError: If the frame is not ICRF_EC.
         """
-        if self.frame != ReferenceFrame.ICRF_EC:
+        if self.frame != ReferenceFrame.get("ICRF_EC"):
             raise ValueError(
                 "Only CartesianState object in ICRF_EC frame is supported for "
                 "conversion to Skyfield GCRF position."

--- a/eosimutils/trajectory.py
+++ b/eosimutils/trajectory.py
@@ -15,7 +15,7 @@ Basic interpolation/resampling and arithmetic operations (with frame conversion)
 import numpy as np
 import spiceypy as spice
 
-from .base import ReferenceFrame
+from .frames import ReferenceFrame
 from .time import AbsoluteDateArray
 from .timeseries import Timeseries
 from .spicekernels import load_spice_kernels

--- a/examples/frame_examples.py
+++ b/examples/frame_examples.py
@@ -6,7 +6,7 @@ from eosimutils.trajectory import StateSeries
 from eosimutils.attitude import AttitudeSeries
 from eosimutils.frame_registry import FrameRegistry
 
-# 1) Build a circular orbit in ICRF_EC
+# Build a circular orbit in ICRF_EC
 μ = 398600.4418           # Earth's GM, km³/s²
 r0 = 7000.0               # orbital radius, km
 omega = np.sqrt(μ / r0**3)    # orbital rate, rad/s
@@ -34,19 +34,14 @@ state_icrf = StateSeries(
     frame=ReferenceFrame.ICRF_EC
 )
 
-# 2) Compute the LVLH attitude series
+# Add LVLH frame
+lvlh_frame = ReferenceFrame.add("LVLH")
 att_lvlh = AttitudeSeries.get_lvlh(state_icrf)
 
-# 3) Register the LVLH frame
-lvlh_frame = ReferenceFrame.add("LVLH")
 registry   = FrameRegistry()
-registry.add_transform(
-    ReferenceFrame.ICRF_EC,
-    lvlh_frame,
-    att_lvlh
-)
+registry.add_transform(att_lvlh)
 
-# 4) Batch‐transform into LVLH
+# Batch‐transform into LVLH
 rot_array, w_array = registry.get_transform(
     ReferenceFrame.ICRF_EC,
     lvlh_frame,
@@ -61,7 +56,7 @@ state_lvlh = StateSeries(
     frame=lvlh_frame
 )
 
-# In LVLH, position should be ~[r0,0,0], velocity ~[0,0,0]
+# In LVLH, position should be ~[0,0,-r0], velocity ~[v0,0,0]
 for t, p_l in zip(et_array, pos_lvlh):
     print(f"t={t:7.1f} s   LVLH pos ≈ {p_l.round(3)}")
 

--- a/examples/frame_examples.py
+++ b/examples/frame_examples.py
@@ -16,6 +16,7 @@ et_array = np.linspace(0.0, 3600.0, 10)
 times = AbsoluteDateArray(et_array)
 
 # positions & velocities in ICRF_EC
+# this is a circular, prograde equatorial orbit
 pos_icrf = np.vstack([
     r0 * np.cos(omega * et_array),
     r0 * np.sin(omega * et_array),
@@ -47,6 +48,7 @@ rot_array, w_array = registry.get_transform(
     lvlh_frame,
     times
 )
+
 pos_lvlh = rot_array.apply(pos_icrf)
 vel_lvlh = rot_array.apply(vel_icrf) + np.cross(w_array, pos_lvlh)
 
@@ -56,7 +58,7 @@ state_lvlh = StateSeries(
     frame=lvlh_frame
 )
 
-# In LVLH, position should be ~[0,0,-r0], velocity ~[v0,0,0]
+# In LVLH, position should be ~[0,0,-r0], velocity ~[0,0,0]
 for t, p_l in zip(et_array, pos_lvlh):
     print(f"t={t:7.1f} s   LVLH pos ≈ {p_l.round(3)}")
 

--- a/examples/frame_examples.py
+++ b/examples/frame_examples.py
@@ -1,0 +1,70 @@
+import numpy as np
+
+from eosimutils.frames import ReferenceFrame
+from eosimutils.time import AbsoluteDate, AbsoluteDateArray
+from eosimutils.trajectory import StateSeries
+from eosimutils.attitude import AttitudeSeries
+from eosimutils.frame_registry import FrameRegistry
+
+# 1) Build a circular orbit in ICRF_EC
+μ = 398600.4418           # Earth's GM, km³/s²
+r0 = 7000.0               # orbital radius, km
+omega = np.sqrt(μ / r0**3)    # orbital rate, rad/s
+
+# sample times: 0 to 3600 s in 10 steps
+et_array = np.linspace(0.0, 3600.0, 10)
+times = AbsoluteDateArray(et_array)
+
+# positions & velocities in ICRF_EC
+pos_icrf = np.vstack([
+    r0 * np.cos(omega * et_array),
+    r0 * np.sin(omega * et_array),
+    np.zeros_like(et_array)
+]).T
+
+vel_icrf = np.vstack([
+    -r0 * omega * np.sin(omega * et_array),
+     r0 * omega * np.cos(omega * et_array),
+     np.zeros_like(et_array)
+]).T
+
+state_icrf = StateSeries(
+    time=times,
+    data=[pos_icrf, vel_icrf],
+    frame=ReferenceFrame.ICRF_EC
+)
+
+# 2) Compute the LVLH attitude series
+att_lvlh = AttitudeSeries.get_lvlh(state_icrf)
+
+# 3) Register the LVLH frame
+lvlh_frame = ReferenceFrame.add("LVLH")
+registry   = FrameRegistry()
+registry.add_transform(
+    ReferenceFrame.ICRF_EC,
+    lvlh_frame,
+    att_lvlh
+)
+
+# 4) Batch‐transform into LVLH
+rot_array, w_array = registry.get_transform(
+    ReferenceFrame.ICRF_EC,
+    lvlh_frame,
+    times
+)
+pos_lvlh = rot_array.apply(pos_icrf)
+vel_lvlh = rot_array.apply(vel_icrf) + np.cross(w_array, pos_lvlh)
+
+state_lvlh = StateSeries(
+    time=times,
+    data=[pos_lvlh, vel_lvlh],
+    frame=lvlh_frame
+)
+
+# In LVLH, position should be ~[r0,0,0], velocity ~[0,0,0]
+for t, p_l in zip(et_array, pos_lvlh):
+    print(f"t={t:7.1f} s   LVLH pos ≈ {p_l.round(3)}")
+
+for t, v_l in zip(et_array, vel_lvlh):
+    print(f"t={t:7.1f} s   LVLH vel ≈ {v_l.round(3)}")
+    

--- a/examples/frame_examples.py
+++ b/examples/frame_examples.py
@@ -32,11 +32,11 @@ vel_icrf = np.vstack([
 state_icrf = StateSeries(
     time=times,
     data=[pos_icrf, vel_icrf],
-    frame=ReferenceFrame.ICRF_EC
+    frame='ReferenceFrame.get("ICRF_EC")'
 )
 
 # Add LVLH frame
-lvlh_frame = ReferenceFrame.add("LVLH")
+lvlh_frame = ReferenceFrame.get("LVLH")
 att_lvlh = OrientationSeries.get_lvlh(state_icrf)
 
 registry   = FrameRegistry()
@@ -44,7 +44,7 @@ registry.add_transform(att_lvlh)
 
 # Batch‐transform into LVLH
 rot_array, w_array = registry.get_transform(
-    ReferenceFrame.ICRF_EC,
+    ReferenceFrame.get("ICRF_EC"),
     lvlh_frame,
     times
 )

--- a/examples/frame_examples.py
+++ b/examples/frame_examples.py
@@ -3,7 +3,7 @@ import numpy as np
 from eosimutils.frames import ReferenceFrame
 from eosimutils.time import AbsoluteDate, AbsoluteDateArray
 from eosimutils.trajectory import StateSeries
-from eosimutils.attitude import AttitudeSeries
+from eosimutils.orientation import OrientationSeries
 from eosimutils.frame_registry import FrameRegistry
 
 # Build a circular orbit in ICRF_EC
@@ -36,7 +36,7 @@ state_icrf = StateSeries(
 
 # Add LVLH frame
 lvlh_frame = ReferenceFrame.add("LVLH")
-att_lvlh = AttitudeSeries.get_lvlh(state_icrf)
+att_lvlh = OrientationSeries.get_lvlh(state_icrf)
 
 registry   = FrameRegistry()
 registry.add_transform(att_lvlh)

--- a/examples/frame_examples.py
+++ b/examples/frame_examples.py
@@ -32,12 +32,12 @@ vel_icrf = np.vstack([
 state_icrf = StateSeries(
     time=times,
     data=[pos_icrf, vel_icrf],
-    frame='ReferenceFrame.get("ICRF_EC")'
+    frame=ReferenceFrame.get("ICRF_EC")
 )
 
 # Add LVLH frame
-lvlh_frame = ReferenceFrame.get("LVLH")
-att_lvlh = OrientationSeries.get_lvlh(state_icrf)
+lvlh_frame = ReferenceFrame.add("LVLH")
+att_lvlh = OrientationSeries.get_lvlh(state_icrf,lvlh_frame)
 
 registry   = FrameRegistry()
 registry.add_transform(att_lvlh)

--- a/examples/trajectory_example.py
+++ b/examples/trajectory_example.py
@@ -43,10 +43,10 @@ velocity1[missing_start:missing_end, :] = np.nan
 traj1 = StateSeries.from_dict({
     "time": abs_dates.to_dict(),
     "data": [position1.tolist(), velocity1.tolist()],
-    "frame": ReferenceFrame.ICRF_EC.to_string(),
+    "frame": ReferenceFrame.get("ICRF_EC").to_string(),
     "headers": [["pos_x", "pos_y", "pos_z"], ["vel_x", "vel_y", "vel_z"]]
 })
-traj1_itrf = traj1.to_frame(ReferenceFrame.ITRF)  # Convert to ITRF frame.
+traj1_itrf = traj1.to_frame(ReferenceFrame.get("ITRF"))  # Convert to ITRF frame.
 
 # Orbit 2: Nearly identical orbit with a small increase in radius.
 dR = 1.0             # km difference.
@@ -63,7 +63,7 @@ velocity2 = np.column_stack((vx2, vy2, vz2))
 traj2 = StateSeries.from_dict({
     "time": abs_dates.to_dict(),
     "data": [position2.tolist(), velocity2.tolist()],
-    "frame": ReferenceFrame.ICRF_EC.to_string(),
+    "frame": ReferenceFrame.get("ICRF_EC").to_string(),
     "headers": [["pos_x", "pos_y", "pos_z"], ["vel_x", "vel_y", "vel_z"]]
 })
 

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -12,7 +12,7 @@ class TestReferenceFrame(unittest.TestCase):
     def test_enum_values(self):
         # Test that all enum values are uppercase
         for frame in ReferenceFrame:
-            self.assertTrue(frame.value.isupper())
+            self.assertTrue(frame.to_string().isupper())
 
     def test_get(self):
         # Test valid input

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -3,7 +3,7 @@
 import unittest
 
 
-from eosimutils.base import ReferenceFrame
+from eosimutils.frames import ReferenceFrame
 
 
 class TestReferenceFrame(unittest.TestCase):

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -7,40 +7,29 @@ from eosimutils.frames import ReferenceFrame
 
 
 class TestReferenceFrame(unittest.TestCase):
-    """Test the ReferenceFrame enum."""
+    """Test the ReferenceFrame class."""
 
-    def test_enum_values(self):
-        # Test that all enum values are uppercase
-        for frame in ReferenceFrame:
+    def test_values_uppercase(self):
+        # Test that all values are uppercase
+        for frame in ReferenceFrame.values():
             self.assertTrue(frame.to_string().isupper())
 
     def test_get(self):
         # Test valid input
-        self.assertEqual(ReferenceFrame.get("ICRF_EC"), ReferenceFrame.ICRF_EC)
-        self.assertEqual(ReferenceFrame.get("ICRF_EC"), ReferenceFrame.ICRF_EC)
-        self.assertEqual(
-            ReferenceFrame.get(["ICRF_EC", "ITRF"]),
-            [ReferenceFrame.ICRF_EC, ReferenceFrame.ITRF],
-        )
-
+        self.assertEqual(ReferenceFrame.get("ICRF_EC"), "ICRF_EC")
         # Test invalid input
         self.assertIsNone(ReferenceFrame.get("INVALID"))
-        self.assertIsNone(ReferenceFrame.get(["ICRF_EC", "INVALID"])[1])
 
     def test_to_string(self):
         # Test string representation
-        self.assertEqual(ReferenceFrame.ICRF_EC.to_string(), "ICRF_EC")
-        self.assertEqual(ReferenceFrame.ITRF.to_string(), "ITRF")
+        self.assertEqual(ReferenceFrame.get("ICRF_EC").to_string(), "ICRF_EC")
+        self.assertEqual(ReferenceFrame.get("ITRF").to_string(), "ITRF")
 
     def test_equality(self):
-        # Test equality with EnumBase
-        self.assertEqual(ReferenceFrame.ICRF_EC, ReferenceFrame.ICRF_EC)
-        self.assertNotEqual(ReferenceFrame.ICRF_EC, ReferenceFrame.ITRF)
-
         # Test equality with string
-        self.assertEqual(ReferenceFrame.ICRF_EC, "ICRF_EC")
-        self.assertNotEqual(ReferenceFrame.ICRF_EC, "ITRF")
+        self.assertEqual(ReferenceFrame.get("ICRF_EC"), "ICRF_EC")
+        self.assertNotEqual(ReferenceFrame.get("ICRF_EC"), "ITRF")
 
         # Test equality with other types
-        self.assertNotEqual(ReferenceFrame.ICRF_EC, 123)
-        self.assertNotEqual(ReferenceFrame.ICRF_EC, None)
+        self.assertNotEqual(ReferenceFrame.get("ICRF_EC"), 123)
+        self.assertNotEqual(ReferenceFrame.get("ICRF_EC"), None)

--- a/tests/test_frameregistry.py
+++ b/tests/test_frameregistry.py
@@ -1,0 +1,98 @@
+"""Unit tests for eosimutils.frame_registry module."""
+
+import unittest
+import numpy as np
+from scipy.spatial.transform import Rotation as R
+
+from eosimutils.frame_registry import FrameRegistry
+from eosimutils.orientation import ConstantOrientation
+from eosimutils.frames import ReferenceFrame
+from eosimutils.time import AbsoluteDate
+
+# Define frames
+ReferenceFrame.add("A")
+ReferenceFrame.add("B")
+ReferenceFrame.add("C")
+ReferenceFrame.add("D")
+ReferenceFrame.add("E")
+ReferenceFrame.add("F")
+
+
+class TestFrameRegistry(unittest.TestCase):
+    """Tests for graph-based frame lookups in FrameRegistry."""
+
+    def setUp(self):
+        self.registry = FrameRegistry()
+
+        # Define 90 deg rotations about Z for edges
+        rot90 = R.from_euler("xyz", [0, 0, 90], degrees=True)
+
+        # Create cycle in graph: A->B->C->D->A
+        self.ab = ConstantOrientation(rot90, ReferenceFrame.A, ReferenceFrame.B)
+        self.registry.add_transform(self.ab)
+        self.bc = ConstantOrientation(rot90, ReferenceFrame.B, ReferenceFrame.C)
+        self.registry.add_transform(self.bc)
+        self.cd = ConstantOrientation(rot90, ReferenceFrame.C, ReferenceFrame.D)
+        self.registry.add_transform(self.cd)
+        self.da = ConstantOrientation(rot90, ReferenceFrame.D, ReferenceFrame.A)
+        self.registry.add_transform(self.da)
+
+        # Create a direct edge from A->C
+        # which gives a shorter path from A->C than A->B->C
+        self.ad = ConstantOrientation(rot90, ReferenceFrame.A, ReferenceFrame.C)
+        self.registry.add_transform(self.ad)
+
+        self.ae = ConstantOrientation(rot90, ReferenceFrame.A, ReferenceFrame.E)
+        self.registry.add_transform(self.ae)
+
+    def test_direct_transform(self):
+        """A single edge A->B should produce a 90 deg rotation about Z."""
+        rot, omega = self.registry.get_transform(
+            ReferenceFrame.A, ReferenceFrame.B, AbsoluteDate(0.0)
+        )
+        np.testing.assert_allclose(
+            rot.as_euler("xyz", degrees=True), [0, 0, 90], atol=1e-8
+        )
+        np.testing.assert_array_equal(omega, np.zeros(3))
+
+    def test_inverse_transform(self):
+        """Requesting B->A uses the auto-registered inverse, yielding −90 deg about Z."""
+        rot, omega = self.registry.get_transform(
+            ReferenceFrame.B, ReferenceFrame.A, AbsoluteDate(0.0)
+        )
+        np.testing.assert_allclose(
+            rot.as_euler("xyz", degrees=True), [0, 0, -90], atol=1e-8
+        )
+        np.testing.assert_array_equal(omega, np.zeros(3))
+
+    def test_two_step_transform(self):
+        """Two‐step path B→D (B→A→D) yields a -180 deg rotation about Z."""
+        rot, omega = self.registry.get_transform(
+            ReferenceFrame.B, ReferenceFrame.D, AbsoluteDate(0.0)
+        )
+        np.testing.assert_allclose(
+            rot.as_euler("xyz", degrees=True), [0, 0, -180], atol=1e-8
+        )
+        np.testing.assert_array_equal(omega, np.zeros(3))
+
+    def test_missing_path_raises(self):
+        """Asking for a non-connected path (A->F) raises KeyError."""
+        with self.assertRaises(KeyError):
+            self.registry.get_transform(
+                ReferenceFrame.A, ReferenceFrame.F, AbsoluteDate(0.0)
+            )
+
+    def test_closest_path(self):
+        """Asking for a transform from (A->C) should return shortest (direct) path.
+        which is the 90 deg rotation."""
+        rot, omega = self.registry.get_transform(
+            ReferenceFrame.A, ReferenceFrame.C, AbsoluteDate(0.0)
+        )
+        np.testing.assert_allclose(
+            rot.as_euler("xyz", degrees=True), [0, 0, 90], atol=1e-8
+        )
+        np.testing.assert_array_equal(omega, np.zeros(3))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_frameregistry.py
+++ b/tests/test_frameregistry.py
@@ -9,7 +9,6 @@ from eosimutils.orientation import ConstantOrientation
 from eosimutils.frames import ReferenceFrame
 from eosimutils.time import AbsoluteDate
 
-# Define frames
 ReferenceFrame.add("A")
 ReferenceFrame.add("B")
 ReferenceFrame.add("C")
@@ -28,27 +27,39 @@ class TestFrameRegistry(unittest.TestCase):
         rot90 = R.from_euler("xyz", [0, 0, 90], degrees=True)
 
         # Create cycle in graph: A->B->C->D->A
-        self.ab = ConstantOrientation(rot90, ReferenceFrame.A, ReferenceFrame.B)
+        self.ab = ConstantOrientation(
+            rot90, ReferenceFrame.get("A"), ReferenceFrame.get("B")
+        )
         self.registry.add_transform(self.ab)
-        self.bc = ConstantOrientation(rot90, ReferenceFrame.B, ReferenceFrame.C)
+        self.bc = ConstantOrientation(
+            rot90, ReferenceFrame.get("B"), ReferenceFrame.get("C")
+        )
         self.registry.add_transform(self.bc)
-        self.cd = ConstantOrientation(rot90, ReferenceFrame.C, ReferenceFrame.D)
+        self.cd = ConstantOrientation(
+            rot90, ReferenceFrame.get("C"), ReferenceFrame.get("D")
+        )
         self.registry.add_transform(self.cd)
-        self.da = ConstantOrientation(rot90, ReferenceFrame.D, ReferenceFrame.A)
+        self.da = ConstantOrientation(
+            rot90, ReferenceFrame.get("D"), ReferenceFrame.get("A")
+        )
         self.registry.add_transform(self.da)
 
         # Create a direct edge from A->C
         # which gives a shorter path from A->C than A->B->C
-        self.ad = ConstantOrientation(rot90, ReferenceFrame.A, ReferenceFrame.C)
+        self.ad = ConstantOrientation(
+            rot90, ReferenceFrame.get("A"), ReferenceFrame.get("C")
+        )
         self.registry.add_transform(self.ad)
 
-        self.ae = ConstantOrientation(rot90, ReferenceFrame.A, ReferenceFrame.E)
+        self.ae = ConstantOrientation(
+            rot90, ReferenceFrame.get("A"), ReferenceFrame.get("E")
+        )
         self.registry.add_transform(self.ae)
 
     def test_direct_transform(self):
         """A single edge A->B should produce a 90 deg rotation about Z."""
         rot, omega = self.registry.get_transform(
-            ReferenceFrame.A, ReferenceFrame.B, AbsoluteDate(0.0)
+            ReferenceFrame.get("A"), ReferenceFrame.get("B"), AbsoluteDate(0.0)
         )
         np.testing.assert_allclose(
             rot.as_euler("xyz", degrees=True), [0, 0, 90], atol=1e-8
@@ -58,7 +69,7 @@ class TestFrameRegistry(unittest.TestCase):
     def test_inverse_transform(self):
         """Requesting B->A uses the auto-registered inverse, yielding −90 deg about Z."""
         rot, omega = self.registry.get_transform(
-            ReferenceFrame.B, ReferenceFrame.A, AbsoluteDate(0.0)
+            ReferenceFrame.get("B"), ReferenceFrame.get("A"), AbsoluteDate(0.0)
         )
         np.testing.assert_allclose(
             rot.as_euler("xyz", degrees=True), [0, 0, -90], atol=1e-8
@@ -68,7 +79,7 @@ class TestFrameRegistry(unittest.TestCase):
     def test_two_step_transform(self):
         """Two‐step path B→D (B→A→D) yields a -180 deg rotation about Z."""
         rot, omega = self.registry.get_transform(
-            ReferenceFrame.B, ReferenceFrame.D, AbsoluteDate(0.0)
+            ReferenceFrame.get("B"), ReferenceFrame.get("D"), AbsoluteDate(0.0)
         )
         np.testing.assert_allclose(
             rot.as_euler("xyz", degrees=True), [0, 0, -180], atol=1e-8
@@ -79,14 +90,16 @@ class TestFrameRegistry(unittest.TestCase):
         """Asking for a non-connected path (A->F) raises KeyError."""
         with self.assertRaises(KeyError):
             self.registry.get_transform(
-                ReferenceFrame.A, ReferenceFrame.F, AbsoluteDate(0.0)
+                ReferenceFrame.get("A"),
+                ReferenceFrame.get("F"),
+                AbsoluteDate(0.0),
             )
 
     def test_closest_path(self):
         """Asking for a transform from (A->C) should return shortest (direct) path.
         which is the 90 deg rotation."""
         rot, omega = self.registry.get_transform(
-            ReferenceFrame.A, ReferenceFrame.C, AbsoluteDate(0.0)
+            ReferenceFrame.get("A"), ReferenceFrame.get("C"), AbsoluteDate(0.0)
         )
         np.testing.assert_allclose(
             rot.as_euler("xyz", degrees=True), [0, 0, 90], atol=1e-8

--- a/tests/test_frames.py
+++ b/tests/test_frames.py
@@ -1,4 +1,4 @@
-"""Unit tests for eosimutils.base module."""
+"""Unit tests for eosimutils.frames module."""
 
 import unittest
 

--- a/tests/test_kinematic.py
+++ b/tests/test_kinematic.py
@@ -26,7 +26,7 @@ _TEST_POSITION_I = Cartesian3DPosition.from_dict(
         "x": random.uniform(-10000, 10000),
         "y": random.uniform(-10000, 10000),
         "z": random.uniform(-10000, 10000),
-        "frame": ReferenceFrame.ICRF_EC,
+        "frame": "ICRF_EC",
     }
 )
 _TEST_VELOCITY_I = Cartesian3DVelocity.from_dict(
@@ -34,7 +34,7 @@ _TEST_VELOCITY_I = Cartesian3DVelocity.from_dict(
         "vx": random.uniform(-10, 10),
         "vy": random.uniform(-10, 10),
         "vz": random.uniform(-10, 10),
-        "frame": ReferenceFrame.ICRF_EC,
+        "frame": "ICRF_EC",
     }
 )
 
@@ -62,7 +62,10 @@ _TEST_TIME = AbsoluteDate.from_dict(
 
 # Example state in inertial frame
 _TEST_STATE_I = CartesianState(
-    _TEST_TIME, _TEST_POSITION_I, _TEST_VELOCITY_I, ReferenceFrame.ICRF_EC
+    _TEST_TIME,
+    _TEST_POSITION_I,
+    _TEST_VELOCITY_I,
+    ReferenceFrame.get("ICRF_EC"),
 )
 
 # Example position in Earth-fixed frame
@@ -71,7 +74,7 @@ _TEST_POSITION_EF = Cartesian3DPosition.from_dict(
         "x": random.uniform(-10000, 10000),
         "y": random.uniform(-10000, 10000),
         "z": random.uniform(-10000, 10000),
-        "frame": ReferenceFrame.ITRF,
+        "frame": "ITRF",
     }
 )
 _TEST_VELOCITY_EF = Cartesian3DVelocity.from_dict(
@@ -79,12 +82,12 @@ _TEST_VELOCITY_EF = Cartesian3DVelocity.from_dict(
         "vx": random.uniform(-10, 10),
         "vy": random.uniform(-10, 10),
         "vz": random.uniform(-10, 10),
-        "frame": ReferenceFrame.ITRF,
+        "frame": "ITRF",
     }
 )
 # Example state in EF frame
 _TEST_STATE_EF = CartesianState(
-    _TEST_TIME, _TEST_POSITION_EF, _TEST_VELOCITY_EF, ReferenceFrame.ITRF
+    _TEST_TIME, _TEST_POSITION_EF, _TEST_VELOCITY_EF, ReferenceFrame.get("ITRF")
 )
 
 
@@ -94,26 +97,28 @@ class TestTransformPosition(unittest.TestCase):
     def test_no_transformation(self):
         """Test no transformation when from_frame and to_frame are the same."""
         transformed_position = transform_position(
-            from_frame=ReferenceFrame.ICRF_EC,
-            to_frame=ReferenceFrame.ICRF_EC,
+            from_frame=ReferenceFrame.get("ICRF_EC"),
+            to_frame=ReferenceFrame.get("ICRF_EC"),
             position=_TEST_POSITION_I,
             time=_TEST_TIME,
         )
         np.testing.assert_array_equal(
             transformed_position.to_list(), _TEST_POSITION_I.to_list()
         )
-        self.assertEqual(transformed_position.frame, ReferenceFrame.ICRF_EC)
+        self.assertEqual(
+            transformed_position.frame, ReferenceFrame.get("ICRF_EC")
+        )
 
     def test_transform_gcrf_to_itrf(self):
         """Test transformation from ICRF_EC to ITRF."""
         transformed_position = transform_position(
-            from_frame=ReferenceFrame.ICRF_EC,
-            to_frame=ReferenceFrame.ITRF,
+            from_frame=ReferenceFrame.get("ICRF_EC"),
+            to_frame=ReferenceFrame.get("ITRF"),
             position=_TEST_POSITION_I,
             time=_TEST_TIME,
         )
         # Validate the transformed position
-        self.assertEqual(transformed_position.frame, ReferenceFrame.ITRF)
+        self.assertEqual(transformed_position.frame, ReferenceFrame.get("ITRF"))
         self.assertEqual(len(transformed_position.to_list()), 3)
         self.assertTrue(
             all(
@@ -127,7 +132,7 @@ class TestTransformPosition(unittest.TestCase):
         with self.assertRaises(NotImplementedError):
             transform_position(
                 from_frame="INVALID_FRAME",
-                to_frame=ReferenceFrame.ITRF,
+                to_frame=ReferenceFrame.get("ITRF"),
                 position=_TEST_POSITION_I,
                 time=_TEST_TIME,
             )
@@ -136,16 +141,16 @@ class TestTransformPosition(unittest.TestCase):
         """Test round-trip transformation from ICRF_EC to ITRF and back to ICRF_EC."""
         # Transform position from ICRF_EC to ITRF
         transformed_to_itrf = transform_position(
-            from_frame=ReferenceFrame.ICRF_EC,
-            to_frame=ReferenceFrame.ITRF,
+            from_frame=ReferenceFrame.get("ICRF_EC"),
+            to_frame=ReferenceFrame.get("ITRF"),
             position=_TEST_POSITION_I,
             time=_TEST_TIME,
         )
 
         # Transform position back from ITRF to ICRF_EC
         transformed_back_to_icrf_ec = transform_position(
-            from_frame=ReferenceFrame.ITRF,
-            to_frame=ReferenceFrame.ICRF_EC,
+            from_frame=ReferenceFrame.get("ITRF"),
+            to_frame=ReferenceFrame.get("ICRF_EC"),
             position=transformed_to_itrf,
             time=_TEST_TIME,
         )
@@ -159,7 +164,7 @@ class TestTransformPosition(unittest.TestCase):
         )
         self.assertEqual(
             transformed_back_to_icrf_ec.frame,
-            ReferenceFrame.ICRF_EC,
+            ReferenceFrame.get("ICRF_EC"),
             "The resulting frame is not ICRF_EC after round-trip transformation.",
         )
 
@@ -170,8 +175,8 @@ class TestTransformPosition(unittest.TestCase):
         (Astropy) frames."""
         # Validate the position transformation from ICRF_EC to ITRF
         is_valid = validate_transform_position_with_astropy(
-            from_frame=ReferenceFrame.ICRF_EC,
-            to_frame=ReferenceFrame.ITRF,
+            from_frame=ReferenceFrame.get("ICRF_EC"),
+            to_frame=ReferenceFrame.get("ITRF"),
             position=_TEST_POSITION_I,
             time=_TEST_TIME,
         )
@@ -179,8 +184,8 @@ class TestTransformPosition(unittest.TestCase):
 
         # Validate the position transformation from ITRF to ICRF_EC
         is_valid = validate_transform_position_with_astropy(
-            from_frame=ReferenceFrame.ITRF,
-            to_frame=ReferenceFrame.ICRF_EC,
+            from_frame=ReferenceFrame.get("ITRF"),
+            to_frame=ReferenceFrame.get("ICRF_EC"),
             position=_TEST_POSITION_EF,
             time=_TEST_TIME,
         )
@@ -193,8 +198,8 @@ class TestTransformState(unittest.TestCase):
     def test_no_transformation(self):
         """Test no transformation when from_frame and to_frame are the same."""
         transformed_state = transform_state(
-            from_frame=ReferenceFrame.ICRF_EC,
-            to_frame=ReferenceFrame.ICRF_EC,
+            from_frame=ReferenceFrame.get("ICRF_EC"),
+            to_frame=ReferenceFrame.get("ICRF_EC"),
             state=_TEST_STATE_I,
             time=_TEST_TIME,
         )
@@ -206,18 +211,18 @@ class TestTransformState(unittest.TestCase):
             transformed_state.velocity.to_list(),
             _TEST_STATE_I.velocity.to_list(),
         )
-        self.assertEqual(transformed_state.frame, ReferenceFrame.ICRF_EC)
+        self.assertEqual(transformed_state.frame, ReferenceFrame.get("ICRF_EC"))
 
     def test_transform_gcrf_to_itrf(self):
         """Test transformation from ICRF_EC to ITRF."""
         transformed_state = transform_state(
-            from_frame=ReferenceFrame.ICRF_EC,
-            to_frame=ReferenceFrame.ITRF,
+            from_frame=ReferenceFrame.get("ICRF_EC"),
+            to_frame=ReferenceFrame.get("ITRF"),
             state=_TEST_STATE_I,
             time=_TEST_TIME,
         )
         # Validate the transformed state
-        self.assertEqual(transformed_state.frame, ReferenceFrame.ITRF)
+        self.assertEqual(transformed_state.frame, ReferenceFrame.get("ITRF"))
         self.assertEqual(len(transformed_state.position.to_list()), 3)
         self.assertEqual(len(transformed_state.velocity.to_list()), 3)
         self.assertTrue(
@@ -238,7 +243,7 @@ class TestTransformState(unittest.TestCase):
         with self.assertRaises(NotImplementedError):
             transform_state(
                 from_frame="INVALID_FRAME",
-                to_frame=ReferenceFrame.ITRF,
+                to_frame=ReferenceFrame.get("ITRF"),
                 state=_TEST_STATE_I,
                 time=_TEST_TIME,
             )
@@ -247,16 +252,16 @@ class TestTransformState(unittest.TestCase):
         """Test round-trip transformation from ICRF_EC to ITRF and back to ICRF_EC."""
         # Transform state from ICRF_EC to ITRF
         transformed_to_itrf = transform_state(
-            from_frame=ReferenceFrame.ICRF_EC,
-            to_frame=ReferenceFrame.ITRF,
+            from_frame=ReferenceFrame.get("ICRF_EC"),
+            to_frame=ReferenceFrame.get("ITRF"),
             state=_TEST_STATE_I,
             time=_TEST_TIME,
         )
 
         # Transform state back from ITRF to ICRF_EC
         transformed_back_to_icrf = transform_state(
-            from_frame=ReferenceFrame.ITRF,
-            to_frame=ReferenceFrame.ICRF_EC,
+            from_frame=ReferenceFrame.get("ITRF"),
+            to_frame=ReferenceFrame.get("ICRF_EC"),
             state=transformed_to_itrf,
             time=_TEST_TIME,
         )
@@ -276,7 +281,7 @@ class TestTransformState(unittest.TestCase):
         )
         self.assertEqual(
             transformed_back_to_icrf.frame,
-            ReferenceFrame.ICRF_EC,
+            ReferenceFrame.get("ICRF_EC"),
             "The resulting frame is not ICRF_EC after round-trip transformation.",
         )
 
@@ -285,8 +290,8 @@ class TestTransformState(unittest.TestCase):
         Validates both position and velocity transformations."""
         # Validate the state transformation from ICRF_EC to ITRF
         is_valid = validate_transform_state_with_astropy(
-            from_frame=ReferenceFrame.ICRF_EC,
-            to_frame=ReferenceFrame.ITRF,
+            from_frame=ReferenceFrame.get("ICRF_EC"),
+            to_frame=ReferenceFrame.get("ITRF"),
             state=_TEST_STATE_I,
             time=_TEST_TIME,
         )
@@ -296,8 +301,8 @@ class TestTransformState(unittest.TestCase):
 
         # Validate the state transformation from ITRF to ICRF_EC
         is_valid = validate_transform_state_with_astropy(
-            from_frame=ReferenceFrame.ITRF,
-            to_frame=ReferenceFrame.ICRF_EC,
+            from_frame=ReferenceFrame.get("ITRF"),
+            to_frame=ReferenceFrame.get("ICRF_EC"),
             state=_TEST_STATE_EF,
             time=_TEST_TIME,
         )

--- a/tests/test_kinematic.py
+++ b/tests/test_kinematic.py
@@ -4,7 +4,7 @@ import unittest
 import numpy as np
 import random
 
-from eosimutils.base import ReferenceFrame
+from eosimutils.frames import ReferenceFrame
 from eosimutils.state import (
     Cartesian3DPosition,
     Cartesian3DVelocity,

--- a/tests/test_orientation.py
+++ b/tests/test_orientation.py
@@ -1,0 +1,199 @@
+"""Unit tests for eosimutils.orientation module."""
+
+import unittest
+import numpy as np
+from scipy.spatial.transform import Rotation as Scipy_Rotation
+from eosimutils.orientation import ConstantOrientation, OrientationSeries
+from eosimutils.time import AbsoluteDate, AbsoluteDateArray
+from eosimutils.frames import ReferenceFrame
+
+
+class TestConstantOrientation(unittest.TestCase):
+    """Test the ConstantOrientation class."""
+
+    # Construct 90 deg rotation about Z axis
+    # and use it to build a ConstantOrientation object
+    # using from_dict with quaternion serialization
+    def setUp(self):
+        # Use built-in frames
+        self.frm = ReferenceFrame.ICRF_EC
+        self.to = ReferenceFrame.ITRF
+        # 90 deg rotation about Z axis
+        self.rotation = Scipy_Rotation.from_euler(
+            "xyz", [0.0, 0.0, 90.0], degrees=True
+        )
+
+        d = {
+            "rotations": self.rotation.as_quat().tolist(),
+            "rotations_type": "quaternion",
+            "from": self.frm.to_string(),
+            "to": self.to.to_string(),
+        }
+        self.co = ConstantOrientation.from_dict(d)
+
+    def test_at_returns_constant_rotation_and_zero_angular_velocity(self):
+        # at(None) should return the same rotation and a zero vector
+        rot, omega = self.co.at(None)
+        np.testing.assert_allclose(
+            rot.as_euler("xyz"), self.rotation.as_euler("xyz"), atol=1e-8
+        )
+        np.testing.assert_array_equal(omega, np.zeros(3))
+
+        # at a single AbsoluteDate
+        t0 = AbsoluteDate(0.0)
+        rot1, omega1 = self.co.at(t0)
+        np.testing.assert_allclose(
+            rot1.as_euler("xyz"), self.rotation.as_euler("xyz"), atol=1e-8
+        )
+        np.testing.assert_array_equal(omega1, np.zeros(3))
+
+        # at an AbsoluteDateArray of length N
+        et = np.array([0.0, 1.0, 2.0])
+        t_arr = AbsoluteDateArray(et)
+        rot_arr, omega_arr = self.co.at(t_arr)
+        self.assertEqual(len(rot_arr), 3)
+        self.assertEqual(omega_arr.shape, (3, 3))
+        actual_eulers = rot_arr.as_euler("xyz")
+        expected_eulers = [self.rotation.as_euler("xyz")] * len(actual_eulers)
+        for act, exp in zip(actual_eulers, expected_eulers):
+            np.testing.assert_allclose(act, exp, atol=1e-8)
+        np.testing.assert_array_equal(omega_arr, np.zeros((3, 3)))
+
+    def test_inverse_swaps_frames_and_inverts_rotation(self):
+        # inverse() should swap from/to and invert the rotation
+        inv = self.co.inverse()
+        self.assertEqual(inv.from_frame, self.to)
+        self.assertEqual(inv.to_frame, self.frm)
+        np.testing.assert_allclose(
+            inv.rotation.as_euler("xyz"),
+            self.rotation.inv().as_euler("xyz"),
+            atol=1e-8,
+        )
+
+    def test_to_dict_and_from_dict_roundtrip(self):
+        # Quaternion‐based serialization
+        d_q = self.co.to_dict(rotations_type="quaternion")
+        co_q = ConstantOrientation.from_dict(d_q)
+        np.testing.assert_allclose(
+            co_q.rotation.as_euler("xyz"),
+            self.rotation.as_euler("xyz"),
+            atol=1e-8,
+        )
+        self.assertEqual(co_q.from_frame, self.frm)
+        self.assertEqual(co_q.to_frame, self.to)
+
+        # Euler‐based serialization
+        d_e = self.co.to_dict(rotations_type="euler")
+        co_e = ConstantOrientation.from_dict(d_e)
+        np.testing.assert_allclose(
+            co_e.rotation.as_euler("xyz"),
+            self.rotation.as_euler("xyz"),
+            atol=1e-8,
+        )
+        self.assertEqual(co_e.from_frame, self.frm)
+        self.assertEqual(co_e.to_frame, self.to)
+
+
+class TestOrientationSeries(unittest.TestCase):
+    """Test the OrientationSeries class."""
+
+    def setUp(self):
+        # Define a constant angular velocity about Z: omega = pi/2 rad/s
+        self.omega = np.array([0.0, 0.0, np.pi / 2])
+        # Time samples t = [0, 1, 2]
+        et = np.array([0.0, 1.0, 2.0])
+        self.times = AbsoluteDateArray(et)
+
+        # Euler angles for pure Z‐axis rotations: [0, 0, omega t]
+        euler_angles = [[0.0, 0.0, self.omega[2] * t] for t in et]
+        # Precompute Scipy rotations for test comparisons
+        self.rotations = Scipy_Rotation.from_euler("xyz", euler_angles)
+
+        # Use built‐in frames
+        self.frm = ReferenceFrame.ICRF_EC
+        self.to = ReferenceFrame.ITRF
+
+        # Construct series via from_dict
+        data_dict = {
+            "time": self.times.to_dict(),
+            "rotations": euler_angles,
+            "rotations_type": "euler",
+            "euler_order": "xyz",
+            "from": self.frm.to_string(),
+            "to": self.to.to_string(),
+        }
+        # angular_velocity omitted so it will be computed internally
+        self.series = OrientationSeries.from_dict(data_dict)
+
+    def test_computed_angular_velocity_is_constant(self):
+        # Computed omega at each sample should match the known omega
+        av = self.series.angular_velocity
+        self.assertEqual(av.shape, (3, 3))
+        for w in av:
+            np.testing.assert_allclose(w, self.omega, atol=1e-8)
+
+    def test_at_method_returns_correct_rotation_and_velocity(self):
+        # at(t=1) should return the second rotation and omega
+        t1 = AbsoluteDate(1.0)
+        rot1, w1 = self.series.at(t1)
+        # Fails if tolerance is one order of magnitude lower
+        np.testing.assert_allclose(
+            rot1.as_euler("xyz"),
+            self.rotations[1].as_euler("xyz"),
+            rtol=1e-5,
+            atol=1e-4,
+        )
+        np.testing.assert_allclose(w1, self.omega, atol=1e-8)
+
+        # at multiple times
+        t_arr = AbsoluteDateArray(np.array([0.5, 1.5]))
+        rot_arr, w_arr = self.series.at(t_arr)
+        # rotations via SLERP: half and three-halves of full step
+        expected_eulers = [[0.0, 0.0, self.omega[2] * t] for t in [0.5, 1.5]]
+        actual_eulers = rot_arr.as_euler("xyz")
+
+        # Fails if tolerance is one order of magnitude lower
+        np.testing.assert_allclose(
+            actual_eulers, expected_eulers, rtol=1e-3, atol=1e-3
+        )
+        # angular velocity picks nearest sample's omega
+        for w in w_arr:
+            np.testing.assert_allclose(w, self.omega, atol=1e-8)
+
+    def test_resample_interpolates_and_preserves_omega(self):
+        # Resample at midpoints [0.5, 1.5]
+        new_et = np.array([0.5, 1.5])
+        new_time = AbsoluteDateArray(new_et)
+        resampled = self.series.resample(new_time)
+        # Check rotations via Euler angles
+        expected_eulers = [[0.0, 0.0, self.omega[2] * t] for t in new_et]
+        actual_eulers = resampled.rotations.as_euler("xyz")
+        np.testing.assert_allclose(
+            actual_eulers, expected_eulers, rtol=1e-4, atol=1e-4
+        )
+        # Check angular velocities
+        for w in resampled.angular_velocity:
+            np.testing.assert_allclose(w, self.omega, atol=1e-8)
+
+    def test_to_dict_and_from_dict_roundtrip(self):
+        # Serialize with Euler angles
+        d = self.series.to_dict(rotations_type="euler", euler_order="xyz")
+        s2 = OrientationSeries.from_dict(d)
+
+        # Rotations should match
+        np.testing.assert_allclose(
+            s2.rotations.as_euler("xyz"),
+            self.series.rotations.as_euler("xyz"),
+            atol=1e-8,
+        )
+        # Angular velocities should match
+        np.testing.assert_allclose(
+            s2.angular_velocity, self.series.angular_velocity, atol=1e-8
+        )
+        # Frames should match
+        self.assertEqual(s2.from_frame, self.frm)
+        self.assertEqual(s2.to_frame, self.to)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_orientation.py
+++ b/tests/test_orientation.py
@@ -21,8 +21,8 @@ class TestConstantOrientation(unittest.TestCase):
     # using from_dict with quaternion serialization
     def setUp(self):
         # Use built-in frames
-        self.frm = ReferenceFrame.ICRF_EC
-        self.to = ReferenceFrame.ITRF
+        self.frm = ReferenceFrame.get("ICRF_EC")
+        self.to = ReferenceFrame.get("ITRF")
         # 90 deg rotation about Z axis
         self.rotation = Scipy_Rotation.from_euler(
             "xyz", [0.0, 0.0, 90.0], degrees=True
@@ -115,8 +115,8 @@ class TestOrientationSeries(unittest.TestCase):
         self.rotations = Scipy_Rotation.from_euler("xyz", euler_angles)
 
         # Use built‐in frames
-        self.frm = ReferenceFrame.ICRF_EC
-        self.to = ReferenceFrame.ITRF
+        self.frm = ReferenceFrame.get("ICRF_EC")
+        self.to = ReferenceFrame.get("ITRF")
 
         # Construct series via from_dict
         data_dict = {
@@ -205,8 +205,8 @@ class TestOrientation(unittest.TestCase):
 
     def test_constant_orientation_from_dict(self):
         # Create a ConstantOrientation and serialize it
-        frm = ReferenceFrame.ICRF_EC
-        to = ReferenceFrame.ITRF
+        frm = ReferenceFrame.get("ICRF_EC")
+        to = ReferenceFrame.get("ITRF")
         rotation = Scipy_Rotation.from_euler(
             "xyz", [0.0, 0.0, 90.0], degrees=True
         )
@@ -224,8 +224,8 @@ class TestOrientation(unittest.TestCase):
 
     def test_orientation_series_from_dict(self):
         # Create an OrientationSeries and serialize it
-        frm = ReferenceFrame.ICRF_EC
-        to = ReferenceFrame.ITRF
+        frm = ReferenceFrame.get("ICRF_EC")
+        to = ReferenceFrame.get("ITRF")
         times = AbsoluteDateArray(np.array([0.0, 1.0, 2.0]))
         rotations = Scipy_Rotation.from_euler(
             "xyz",
@@ -252,8 +252,8 @@ class TestOrientation(unittest.TestCase):
 
     def test_spice_orientation_from_dict(self):
         # Create a SpiceOrientation and serialize it
-        frm = ReferenceFrame.ICRF_EC
-        to = ReferenceFrame.ITRF
+        frm = ReferenceFrame.get("ICRF_EC")
+        to = ReferenceFrame.get("ITRF")
         spice_orientation = SpiceOrientation(frm, to)
         data = spice_orientation.to_dict()
 

--- a/tests/test_orientation.py
+++ b/tests/test_orientation.py
@@ -3,7 +3,12 @@
 import unittest
 import numpy as np
 from scipy.spatial.transform import Rotation as Scipy_Rotation
-from eosimutils.orientation import ConstantOrientation, OrientationSeries
+from eosimutils.orientation import (
+    ConstantOrientation,
+    OrientationSeries,
+    Orientation,
+    SpiceOrientation,
+)
 from eosimutils.time import AbsoluteDate, AbsoluteDateArray
 from eosimutils.frames import ReferenceFrame
 
@@ -193,6 +198,70 @@ class TestOrientationSeries(unittest.TestCase):
         # Frames should match
         self.assertEqual(s2.from_frame, self.frm)
         self.assertEqual(s2.to_frame, self.to)
+
+
+class TestOrientation(unittest.TestCase):
+    """Test the factory pattern for Orientation subclasses."""
+
+    def test_constant_orientation_from_dict(self):
+        # Create a ConstantOrientation and serialize it
+        frm = ReferenceFrame.ICRF_EC
+        to = ReferenceFrame.ITRF
+        rotation = Scipy_Rotation.from_euler(
+            "xyz", [0.0, 0.0, 90.0], degrees=True
+        )
+        co = ConstantOrientation(rotation, frm, to)
+        data = co.to_dict(rotations_type="quaternion")
+
+        # Deserialize using the factory method
+        co_from_dict = Orientation.from_dict(data)
+        self.assertIsInstance(co_from_dict, ConstantOrientation)
+        np.testing.assert_allclose(
+            co_from_dict.rotation.as_quat(), rotation.as_quat(), atol=1e-8
+        )
+        self.assertEqual(co_from_dict.from_frame, frm)
+        self.assertEqual(co_from_dict.to_frame, to)
+
+    def test_orientation_series_from_dict(self):
+        # Create an OrientationSeries and serialize it
+        frm = ReferenceFrame.ICRF_EC
+        to = ReferenceFrame.ITRF
+        times = AbsoluteDateArray(np.array([0.0, 1.0, 2.0]))
+        rotations = Scipy_Rotation.from_euler(
+            "xyz",
+            [[0.0, 0.0, 0.0], [0.0, 0.0, 90.0], [0.0, 0.0, 180.0]],
+            degrees=True,
+        )
+        angular_velocity = np.array([[0.0, 0.0, np.pi / 2]] * 3)
+        series = OrientationSeries(times, rotations, frm, to, angular_velocity)
+        data = series.to_dict(rotations_type="euler", euler_order="xyz")
+
+        # Deserialize using the factory method
+        series_from_dict = Orientation.from_dict(data)
+        self.assertIsInstance(series_from_dict, OrientationSeries)
+        np.testing.assert_allclose(
+            series_from_dict.rotations.as_euler("xyz"),
+            rotations.as_euler("xyz"),
+            atol=1e-8,
+        )
+        np.testing.assert_allclose(
+            series_from_dict.angular_velocity, angular_velocity, atol=1e-8
+        )
+        self.assertEqual(series_from_dict.from_frame, frm)
+        self.assertEqual(series_from_dict.to_frame, to)
+
+    def test_spice_orientation_from_dict(self):
+        # Create a SpiceOrientation and serialize it
+        frm = ReferenceFrame.ICRF_EC
+        to = ReferenceFrame.ITRF
+        spice_orientation = SpiceOrientation(frm, to)
+        data = spice_orientation.to_dict()
+
+        # Deserialize using the factory method
+        spice_from_dict = Orientation.from_dict(data)
+        self.assertIsInstance(spice_from_dict, SpiceOrientation)
+        self.assertEqual(spice_from_dict.from_frame, frm)
+        self.assertEqual(spice_from_dict.to_frame, to)
 
 
 if __name__ == "__main__":

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -27,21 +27,21 @@ class TestCartesian3DPosition(unittest.TestCase):
 
     def test_initialization(self):
         pos = Cartesian3DPosition(
-            self.x, self.y, self.z, ReferenceFrame.ICRF_EC
+            self.x, self.y, self.z, ReferenceFrame.get("ICRF_EC")
         )
         np.testing.assert_array_equal(pos.coords, [self.x, self.y, self.z])
-        self.assertEqual(pos.frame, ReferenceFrame.ICRF_EC)
+        self.assertEqual(pos.frame, ReferenceFrame.get("ICRF_EC"))
 
     def test_from_array(self):
         pos = Cartesian3DPosition.from_array(
-            [self.x, self.y, self.z], ReferenceFrame.ITRF
+            [self.x, self.y, self.z], ReferenceFrame.get("ITRF")
         )
         np.testing.assert_array_equal(pos.coords, [self.x, self.y, self.z])
-        self.assertEqual(pos.frame, ReferenceFrame.ITRF)
+        self.assertEqual(pos.frame, ReferenceFrame.get("ITRF"))
 
         pos = Cartesian3DPosition.from_array([self.x, self.y, self.z], "ITRF")
         np.testing.assert_array_equal(pos.coords, [self.x, self.y, self.z])
-        self.assertEqual(pos.frame, ReferenceFrame.ITRF)
+        self.assertEqual(pos.frame, ReferenceFrame.get("ITRF"))
 
         pos = Cartesian3DPosition.from_array([self.x, self.y, self.z])
         np.testing.assert_array_equal(pos.coords, [self.x, self.y, self.z])
@@ -49,7 +49,7 @@ class TestCartesian3DPosition(unittest.TestCase):
 
     def test_to_numpy(self):
         pos = Cartesian3DVelocity(
-            self.x, self.y, self.z, ReferenceFrame.ICRF_EC
+            self.x, self.y, self.z, ReferenceFrame.get("ICRF_EC")
         )
         self.assertIsInstance(pos.to_numpy(), np.ndarray)
         np.testing.assert_array_equal(
@@ -58,7 +58,7 @@ class TestCartesian3DPosition(unittest.TestCase):
 
     def test_to_list(self):
         pos = Cartesian3DPosition(
-            self.x, self.y, self.z, ReferenceFrame.ICRF_EC
+            self.x, self.y, self.z, ReferenceFrame.get("ICRF_EC")
         )
         self.assertEqual(pos.to_list(), [self.x, self.y, self.z])
 
@@ -66,7 +66,7 @@ class TestCartesian3DPosition(unittest.TestCase):
         dict_in = {"x": self.x, "y": self.y, "z": self.z, "frame": "ICRF_EC"}
         pos = Cartesian3DPosition.from_dict(dict_in)
         np.testing.assert_array_equal(pos.coords, [self.x, self.y, self.z])
-        self.assertEqual(pos.frame, ReferenceFrame.ICRF_EC)
+        self.assertEqual(pos.frame, ReferenceFrame.get("ICRF_EC"))
 
     def test_from_dict_no_frame(self):
         dict_in = {"x": self.x, "y": self.y, "z": self.z}
@@ -75,7 +75,9 @@ class TestCartesian3DPosition(unittest.TestCase):
         self.assertIsNone(pos.frame)
 
     def test_to_dict(self):
-        pos = Cartesian3DPosition(self.x, self.y, self.z, ReferenceFrame.ITRF)
+        pos = Cartesian3DPosition(
+            self.x, self.y, self.z, ReferenceFrame.get("ITRF")
+        )
         dict_out = pos.to_dict()
         self.assertEqual(dict_out["x"], self.x)
         self.assertEqual(dict_out["y"], self.y)
@@ -93,23 +95,23 @@ class TestCartesian3DVelocity(unittest.TestCase):
 
     def test_initialization(self):
         vel = Cartesian3DVelocity(
-            self.vx, self.vy, self.vz, ReferenceFrame.ICRF_EC
+            self.vx, self.vy, self.vz, ReferenceFrame.get("ICRF_EC")
         )
         np.testing.assert_array_equal(vel.coords, [self.vx, self.vy, self.vz])
-        self.assertEqual(vel.frame, ReferenceFrame.ICRF_EC)
+        self.assertEqual(vel.frame, ReferenceFrame.get("ICRF_EC"))
 
     def test_from_array(self):
         vel = Cartesian3DVelocity.from_array(
-            [self.vx, self.vy, self.vz], ReferenceFrame.ITRF
+            [self.vx, self.vy, self.vz], ReferenceFrame.get("ITRF")
         )
         np.testing.assert_array_equal(vel.coords, [self.vx, self.vy, self.vz])
-        self.assertEqual(vel.frame, ReferenceFrame.ITRF)
+        self.assertEqual(vel.frame, ReferenceFrame.get("ITRF"))
 
         vel = Cartesian3DVelocity.from_array(
             [self.vx, self.vy, self.vz], "ITRF"
         )
         np.testing.assert_array_equal(vel.coords, [self.vx, self.vy, self.vz])
-        self.assertEqual(vel.frame, ReferenceFrame.ITRF)
+        self.assertEqual(vel.frame, ReferenceFrame.get("ITRF"))
 
         vel = Cartesian3DVelocity.from_array([self.vx, self.vy, self.vz])
         np.testing.assert_array_equal(vel.coords, [self.vx, self.vy, self.vz])
@@ -117,7 +119,7 @@ class TestCartesian3DVelocity(unittest.TestCase):
 
     def test_to_numpy(self):
         vel = Cartesian3DVelocity(
-            self.vx, self.vy, self.vz, ReferenceFrame.ICRF_EC
+            self.vx, self.vy, self.vz, ReferenceFrame.get("ICRF_EC")
         )
         self.assertIsInstance(vel.to_numpy(), np.ndarray)
         np.testing.assert_array_equal(
@@ -126,7 +128,7 @@ class TestCartesian3DVelocity(unittest.TestCase):
 
     def test_to_list(self):
         vel = Cartesian3DVelocity(
-            self.vx, self.vy, self.vz, ReferenceFrame.ICRF_EC
+            self.vx, self.vy, self.vz, ReferenceFrame.get("ICRF_EC")
         )
         self.assertIsInstance(vel.to_list(), list)
         self.assertEqual(vel.to_list(), [self.vx, self.vy, self.vz])
@@ -140,7 +142,7 @@ class TestCartesian3DVelocity(unittest.TestCase):
         }
         vel = Cartesian3DVelocity.from_dict(dict_in)
         np.testing.assert_array_equal(vel.coords, [self.vx, self.vy, self.vz])
-        self.assertEqual(vel.frame, ReferenceFrame.ICRF_EC)
+        self.assertEqual(vel.frame, ReferenceFrame.get("ICRF_EC"))
 
     def from_dict_no_frame(self):
         dict_in = {"vx": self.vx, "vy": self.vy, "vz": self.vz}
@@ -150,7 +152,7 @@ class TestCartesian3DVelocity(unittest.TestCase):
 
     def test_to_dict(self):
         vel = Cartesian3DVelocity(
-            self.vx, self.vy, self.vz, ReferenceFrame.ITRF
+            self.vx, self.vy, self.vz, ReferenceFrame.get("ITRF")
         )
         dict_out = vel.to_dict()
         np.testing.assert_array_equal(vel.coords, [self.vx, self.vy, self.vz])
@@ -281,7 +283,7 @@ class TestCartesianState(unittest.TestCase):
         }
         self.velocity = Cartesian3DVelocity.from_dict(self.velocity_dict)
 
-        self.frame = ReferenceFrame.ICRF_EC
+        self.frame = ReferenceFrame.get("ICRF_EC")
 
     def test_initialization(self):
         state = CartesianState(
@@ -315,7 +317,7 @@ class TestCartesianState(unittest.TestCase):
 
         with self.assertRaises(ValueError) as context:
             CartesianState(
-                self.time, position, velocity, ReferenceFrame.ICRF_EC
+                self.time, position, velocity, ReferenceFrame.get("ICRF_EC")
             )
 
         self.assertTrue(
@@ -420,16 +422,16 @@ class TestCartesianState(unittest.TestCase):
             self.position.coords[0],
             self.position.coords[1],
             self.position.coords[2],
-            ReferenceFrame.ITRF,
+            ReferenceFrame.get("ITRF"),
         )
         velocity = Cartesian3DVelocity(
             self.velocity.coords[0],
             self.velocity.coords[1],
             self.velocity.coords[2],
-            ReferenceFrame.ITRF,
+            ReferenceFrame.get("ITRF"),
         )
         state = CartesianState(
-            self.time, position, velocity, ReferenceFrame.ITRF
+            self.time, position, velocity, ReferenceFrame.get("ITRF")
         )
 
         # Check that ValueError is raised

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -8,7 +8,7 @@ from astropy.coordinates import EarthLocation as Astropy_EarthLocation
 import astropy.units as astropy_u
 
 from eosimutils.time import AbsoluteDate
-from eosimutils.base import ReferenceFrame
+from eosimutils.frames import ReferenceFrame
 from eosimutils.state import (
     Cartesian3DPosition,
     Cartesian3DVelocity,

--- a/tests/test_trajectory.py
+++ b/tests/test_trajectory.py
@@ -4,7 +4,7 @@ import unittest
 import numpy as np
 from eosimutils.trajectory import StateSeries, PositionSeries
 from eosimutils.time import AbsoluteDateArray, AbsoluteDate, JD_OF_J2000
-from eosimutils.base import ReferenceFrame
+from eosimutils.frames import ReferenceFrame
 from eosimutils.state import (
     CartesianState,
     Cartesian3DPosition,

--- a/tests/test_trajectory.py
+++ b/tests/test_trajectory.py
@@ -235,7 +235,7 @@ class TestPositionSeries:
             }
         )
         data = np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
-        frame = ReferenceFrame.ICRF_EC
+        frame = ReferenceFrame.get("ICRF_EC")
         ps = PositionSeries.from_dict(
             {
                 "time": time.to_dict("JULIAN_DATE"),
@@ -253,7 +253,7 @@ class TestPositionSeries:
             np.array([JD_OF_J2000 + t for t in [0.0, 1.0]])
         )
         data = np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
-        frame = ReferenceFrame.ICRF_EC
+        frame = ReferenceFrame.get("ICRF_EC")
         ps = PositionSeries(time, data, frame)
         new_time = np.array([JD_OF_J2000 + 0.5])
         resampled_ps = ps.resample(new_time)
@@ -267,7 +267,7 @@ class TestPositionSeries:
         data = np.array(
             [[1.0, 2.0, 3.0], [np.nan, np.nan, np.nan], [4.0, 5.0, 6.0]]
         )
-        frame = ReferenceFrame.ICRF_EC
+        frame = ReferenceFrame.get("ICRF_EC")
         ps = PositionSeries(time, data, frame)
         gapless_ps = ps.remove_gaps()
         assert gapless_ps.data[0].shape == (2, 3)
@@ -278,16 +278,16 @@ class TestPositionSeries:
             np.array([JD_OF_J2000 + t for t in [0.0, 1.0]])
         )
         data = np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
-        frame = ReferenceFrame.ICRF_EC
+        frame = ReferenceFrame.get("ICRF_EC")
         ps = PositionSeries(time, data, frame)
-        converted_ps = ps.to_frame(ReferenceFrame.ITRF)
-        assert converted_ps.frame == ReferenceFrame.ITRF
+        converted_ps = ps.to_frame(ReferenceFrame.get("ITRF"))
+        assert converted_ps.frame == ReferenceFrame.get("ITRF")
 
     def test_from_list_of_cartesian_position(self):
         """Test creation of PositionSeries from a list of Cartesian3DPosition objects."""
         positions = [
-            Cartesian3DPosition(1.0, 2.0, 3.0, ReferenceFrame.ICRF_EC),
-            Cartesian3DPosition(4.0, 5.0, 6.0, ReferenceFrame.ICRF_EC),
+            Cartesian3DPosition(1.0, 2.0, 3.0, ReferenceFrame.get("ICRF_EC")),
+            Cartesian3DPosition(4.0, 5.0, 6.0, ReferenceFrame.get("ICRF_EC")),
         ]
         for pos in positions:
             pos.time = AbsoluteDateArray(
@@ -295,7 +295,7 @@ class TestPositionSeries:
             )  # Mock time attribute
         ps = PositionSeries.from_list_of_cartesian_position(positions)
         assert ps.data[0].shape == (2, 3)
-        assert ps.frame == ReferenceFrame.ICRF_EC
+        assert ps.frame == ReferenceFrame.get("ICRF_EC")
 
     def test_arithmetic_operations(self):
         """Test arithmetic operations between PositionSeries."""
@@ -304,7 +304,7 @@ class TestPositionSeries:
         )
         data1 = np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0], [7.0, 8.0, 9.0]])
         data2 = np.array([[0.5, 1.5, 2.5], [3.5, 4.5, 5.5], [6.5, 7.5, 8.5]])
-        frame = ReferenceFrame.ICRF_EC
+        frame = ReferenceFrame.get("ICRF_EC")
 
         ps1 = PositionSeries(time, data1, frame)
         ps2 = PositionSeries(time, data2, frame)

--- a/tests/testutils.py
+++ b/tests/testutils.py
@@ -6,7 +6,7 @@ from typing import Union
 from eosimutils.thirdpartyutils import astropy_transform
 from eosimutils.state import Cartesian3DPosition, CartesianState
 from eosimutils.time import AbsoluteDate
-from eosimutils.base import ReferenceFrame
+from eosimutils.frames import ReferenceFrame
 from eosimutils.kinematic import transform_position, transform_state
 
 

--- a/tests/testutils.py
+++ b/tests/testutils.py
@@ -38,20 +38,20 @@ def validate_transform_position_with_astropy(
 
     # Transform using astropy
     # get the frame names in format accepted by astropy
-    if (
-        from_frame == "GCRF" or from_frame == ReferenceFrame.ICRF_EC
+    if from_frame == "GCRF" or from_frame == ReferenceFrame.get(
+        "ICRF_EC"
     ):  # Orientation of ICRF ~ orientation of GCRF
         from_frame_str = "GCRS"
-    elif from_frame == "ITRF" or from_frame == ReferenceFrame.ITRF:
+    elif from_frame == "ITRF" or from_frame == ReferenceFrame.get("ITRF"):
         from_frame_str = "ITRS"
     else:
         raise ValueError(f"Unsupported from_frame: {from_frame}")
 
-    if (
-        to_frame == "GCRF" or to_frame == ReferenceFrame.ICRF_EC
+    if to_frame == "GCRF" or to_frame == ReferenceFrame.get(
+        "ICRF_EC"
     ):  # Orientation of ICRF ~ orientation of GCRF
         to_frame_str = "GCRS"
-    elif to_frame == "ITRF" or to_frame == ReferenceFrame.ITRF:
+    elif to_frame == "ITRF" or to_frame == ReferenceFrame.get("ITRF"):
         to_frame_str = "ITRS"
     else:
         raise ValueError(f"Unsupported to_frame: {to_frame}")
@@ -104,16 +104,16 @@ def validate_transform_state_with_astropy(
     )
 
     # Get the frame names in a format accepted by astropy
-    if from_frame == "GCRF" or from_frame == ReferenceFrame.ICRF_EC:
+    if from_frame == "GCRF" or from_frame == ReferenceFrame.get("ICRF_EC"):
         from_frame_str = "GCRS"
-    elif from_frame == "ITRF" or from_frame == ReferenceFrame.ITRF:
+    elif from_frame == "ITRF" or from_frame == ReferenceFrame.get("ITRF"):
         from_frame_str = "ITRS"
     else:
         raise ValueError(f"Unsupported from_frame: {from_frame}")
 
-    if to_frame == "GCRF" or to_frame == ReferenceFrame.ICRF_EC:
+    if to_frame == "GCRF" or to_frame == ReferenceFrame.get("ICRF_EC"):
         to_frame_str = "GCRS"
-    elif to_frame == "ITRF" or to_frame == ReferenceFrame.ITRF:
+    elif to_frame == "ITRF" or to_frame == ReferenceFrame.get("ITRF"):
         to_frame_str = "ITRS"
     else:
         raise ValueError(f"Unsupported to_frame: {to_frame}")


### PR DESCRIPTION
New modules added:

orientation.py
  - Module for representing reference frame transformations. Has a base class "Orientation" which is extended by "SpiceOrientation", "ConstantOrientation", and "OrientationSeries". Uses a factory pattern so that subclass objects can be built from Orientation.from_dict.

frames.py
 - New implementation for the ReferenceFrame class which allows dynamic addition of frames.

frame_registry.py
  - Stores frame transformations in a graph. Frame transformations can be retrieved if there is a path from one node (reference frame) to another.